### PR TITLE
fix: add the functionality to update the update interval after savin…

### DIFF
--- a/src/main/utils/ipc.ts
+++ b/src/main/utils/ipc.ts
@@ -89,6 +89,7 @@ import { getImageDataURL } from './image'
 import { startMonitor } from '../resolve/trafficMonitor'
 import { closeFloatingWindow, showContextMenu, showFloatingWindow } from '../resolve/floatingWindow'
 import i18next from 'i18next'
+import { addProfileUpdater } from '../core/profileUpdater'
 
 function ipcErrorWrapper<T>( // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fn: (...args: any[]) => Promise<T> // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -163,6 +164,7 @@ export function registerIpcMainHandlers(): void {
   ipcMain.handle('changeCurrentProfile', (_e, id) => ipcErrorWrapper(changeCurrentProfile)(id))
   ipcMain.handle('addProfileItem', (_e, item) => ipcErrorWrapper(addProfileItem)(item))
   ipcMain.handle('removeProfileItem', (_e, id) => ipcErrorWrapper(removeProfileItem)(id))
+  ipcMain.handle('addProfileUpdater', (_e, item) => ipcErrorWrapper(addProfileUpdater)(item))
   ipcMain.handle('getOverrideConfig', (_e, force) => ipcErrorWrapper(getOverrideConfig)(force))
   ipcMain.handle('setOverrideConfig', (_e, config) => ipcErrorWrapper(setOverrideConfig)(config))
   ipcMain.handle('getOverrideItem', (_e, id) => ipcErrorWrapper(getOverrideItem)(id))

--- a/src/renderer/src/components/profiles/edit-info-modal.tsx
+++ b/src/renderer/src/components/profiles/edit-info-modal.tsx
@@ -16,7 +16,7 @@ import {
 import React, { useState } from 'react'
 import SettingItem from '../base/base-setting-item'
 import { useOverrideConfig } from '@renderer/hooks/use-override-config'
-import { restartCore } from '@renderer/utils/ipc'
+import { restartCore, addProfileUpdater } from '@renderer/utils/ipc'
 import { MdDeleteForever } from 'react-icons/md'
 import { FaPlus } from 'react-icons/fa6'
 import { useTranslation } from 'react-i18next'
@@ -36,13 +36,15 @@ const EditInfoModal: React.FC<Props> = (props) => {
 
   const onSave = async (): Promise<void> => {
     try {
-      await updateProfileItem({
+      const updatedItem = {
         ...values,
         override: values.override?.filter(
           (i) =>
             overrideItems.find((t) => t.id === i) && !overrideItems.find((t) => t.id === i)?.global
         )
-      })
+      };
+      await updateProfileItem(updatedItem)
+      await addProfileUpdater(updatedItem)
       await restartCore()
       onClose()
     } catch (e) {

--- a/src/renderer/src/utils/ipc.ts
+++ b/src/renderer/src/utils/ipc.ts
@@ -147,6 +147,10 @@ export async function updateProfileItem(item: IProfileItem): Promise<void> {
   return ipcErrorWrapper(await window.electron.ipcRenderer.invoke('updateProfileItem', item))
 }
 
+export async function addProfileUpdater(item: IProfileItem): Promise<void> {
+  return ipcErrorWrapper(await window.electron.ipcRenderer.invoke('addProfileUpdater', item))
+}
+
 export async function getProfileStr(id: string): Promise<string> {
   return ipcErrorWrapper(await window.electron.ipcRenderer.invoke('getProfileStr', id))
 }


### PR DESCRIPTION
**描述:**

本次提交修复了一个问题：当用户在 Profile 设置中修改了更新间隔并保存后，新的间隔时间不会立即生效。之前的行为可能需要等待下一个基于旧间隔的计划更新时间点到达，或者需要重启应用才能应用新的设置。

**此 PR 实现了以下功能：**

1.  **即时更新定时器：** 当用户在编辑 Profile 信息弹窗中点击保存按钮时，除了更新 Profile 配置本身 (`updateProfileItem`)，现在还会立即调用一个新的 IPC 事件 (`addProfileUpdater`)。用户修改 Profile 的自动更新间隔并保存后，该设置会 **立即生效**。计时器会根据新的间隔重新启动，确保下一次自动更新会在正确的时间点发生，无需等待或重启。
2.  **`addProfileUpdater` 处理：**
    * 在 `renderer` 进程中，`edit-info-modal.tsx` 组件在 `onSave` 函数中调用了新的 `addProfileUpdater` 函数。
    * 在 `main` 进程中，注册了相应的 `ipcMain` handler (`handle('addProfileUpdater', ...)`), 它会调用核心的 `addProfileUpdater` 逻辑（位于 `main/core/profileUpdater.ts`）。
    * 这个核心逻辑负责根据传入的 Profile Item (包含新的更新间隔 `interval`) 来重置或添加该 Profile 的更新定时器。

