### PR TITLE
fix: apply DNS hosts only if useHosts is true

### DIFF
--- a/src/renderer/src/pages/dns.tsx
+++ b/src/renderer/src/pages/dns.tsx
@@ -142,9 +142,6 @@ const DNS: React.FC = () => {
             className="app-nodrag"
             color="primary"
             onPress={() => {
-              const hostsObject = Object.fromEntries(
-                values.hosts.map(({ domain, value }) => [domain, value])
-              )
               const dnsConfig = {
                 ipv6: values.ipv6,
                 'fake-ip-range': values.fakeIPRange,
@@ -165,10 +162,13 @@ const DNS: React.FC = () => {
                   values.nameserverPolicy.map(({ domain, value }) => [domain, value])
                 )
               }
-              onSave({
-                dns: dnsConfig,
-                hosts: hostsObject
-              })
+              const result = { dns: dnsConfig }
+              if (values.useHosts) {
+                result['hosts'] = Object.fromEntries(
+                  values.hosts.map(({ domain, value }) => [domain, value])
+                )
+              }
+              onSave(result)
             }}
           >
             {t('common.save')}


### PR DESCRIPTION
修复了 DNS hosts 设置在 `useHosts` 不为 true 时也会被错误应用的问题。现在只有当 `useHosts` 明确设置为 `true` 时，才会应用相关的 hosts 配置。