### PR TITLE
fix: synchronization issue with gist after mihomo core 1.19.8 update

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -158,7 +158,7 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
         resolve([
           new Promise((resolve) => {
             child.stdout?.on('data', async (data) => {
-              if (data.toString().includes('Start initial Compatible provider default')) {
+              if (data.toString().toLowerCase().includes('start initial compatible provider default')) {
                 try {
                   mainWindow?.webContents.send('groupsUpdated')
                   mainWindow?.webContents.send('rulesUpdated')


### PR DESCRIPTION
# 修复了内核1.19.8更新后gist同步失效的问题

## 目的
本次修改解决了mihomo内核升级到1.19.8版本后，gist配置同步功能失效的问题。内核输出信息从"Start initial Compatible provider default"变更为"Start initial compatible provider default"，导致无法正确识别初始化完成事件，进而无法触发配置同步。
![QQ_1749397369818](https://github.com/user-attachments/assets/3a2a883d-a061-4274-8e62-abf7ad4a32d5)

## 改进建议
通过字符串匹配内核输出来判断内核行为是非常不靠谱的方式，容易因内核版本更新或文本微小变化而失效。在后续版本中，此类问题可能会再次发生。

此次修改仅为临时解决方案，长期来看应当重新设计此功能以提高稳定性。
