### PR TITLE
fix: prevent scientific notation parsing in YAML

### DIFF
--- a/src/main/config/profile.ts
+++ b/src/main/config/profile.ts
@@ -205,7 +205,10 @@ export async function setProfileStr(id: string, content: string): Promise<void> 
 
 export async function getProfile(id: string | undefined): Promise<IMihomoConfig> {
   const profile = await getProfileStr(id)
-  let result = yaml.parse(profile, { merge: true }) || {}
+  
+  // 替换 防止错误使用科学记数法解析
+  const patchedProfile = profile.replace(/(\w+:\s*)(\d+E\d+)(\s|$)/gi, '$1"$2"$3')
+  let result = yaml.parse(patchedProfile, { merge: true }) || {}
   if (typeof result !== 'object') result = {}
   return result
 }

--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -50,7 +50,16 @@ export async function generateProfile(): Promise<void> {
     profile['log-level'] = 'info'
   }
   runtimeConfig = profile
-  runtimeConfigStr = yaml.stringify(profile)
+  
+  // 先正常生成 YAML 字符串
+  let yamlStr = yaml.stringify(profile)
+  // 还原科学记数法的引号
+  yamlStr = yamlStr.replace(
+    /(\w+:\s*)"(\d+E\d+)"(\s|$)/gi,
+    '$1$2$3'
+  )
+  runtimeConfigStr = yamlStr
+  
   if (diffWorkDir) {
     await prepareProfileWorkDir(current)
   }


### PR DESCRIPTION
fix #889 