### PR TITLE
fix: correct split logic in parseSubinfo

### DIFF
--- a/src/main/config/profile.ts
+++ b/src/main/config/profile.ts
@@ -226,7 +226,7 @@ function parseFilename(str: string): string {
 
 // subscription-userinfo: upload=1234; download=2234; total=1024000; expire=2218532293
 function parseSubinfo(str: string): ISubscriptionUserInfo {
-  const parts = str.split('; ')
+  const parts = str.split(/\s*;\s*/)
   const obj = {} as ISubscriptionUserInfo
   parts.forEach((part) => {
     const [key, value] = part.split('=')


### PR DESCRIPTION
fix #951 