### PR TITLE
feat: 修复权限检查并优化TUN与自启联动

### DIFF
--- a/src/renderer/src/components/sider/tun-switcher.tsx
+++ b/src/renderer/src/components/sider/tun-switcher.tsx
@@ -75,6 +75,9 @@ const TunSwitcher: React.FC<Props> = (props) => {
       }
 
       await patchControledMihomoConfig({ tun: { enable }, dns: { enable: true } })
+      if (enable && appConfig?.silentStart) {
+        await window.electron.ipcRenderer.invoke('enableAutoRun')
+      }
     } else {
       await patchControledMihomoConfig({ tun: { enable } })
     }


### PR DESCRIPTION
1. 修复管理员权限检查不准导致TUN无法开启的问题
   - 增加 'fltmc' 命令作为主要判断，'net session' 作为备用，提高在特定环境下的准确性。

2. 优化自启动以自动保持TUN模式开启
   - 设置自启动时，根据当前运行身份决定任务权限。
   - 为TUN模式提权而重启后，若自启已开启，则自动将计划任务更新为管理员权限。
   - 普通权限启动但TUN开启时，主动提示用户需以管理员身份重启。