### PR TITLE
fix: 优化DNS、内核设置等默认配置提升性能及稳定性

### DIFF
--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -44,11 +44,6 @@ export async function generateProfile(): Promise<void> {
   }
 
   const profile = deepMerge(currentProfile, controledMihomoConfig)
-  // 确保可以拿到基础日志信息
-  // 使用 debug 可以调试内核相关问题 `debug/pprof`
-  if (['info', 'debug'].includes(profile['log-level']) === false) {
-    profile['log-level'] = 'info'
-  }
   runtimeConfig = profile
   
   // 先正常生成 YAML 字符串

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -7,7 +7,8 @@ import {
   mihomoProfileWorkDir,
   mihomoTestDir,
   mihomoWorkConfigPath,
-  mihomoWorkDir
+  mihomoWorkDir,
+  mihomoIpcPath
 } from '../utils/dirs'
 import { generateProfile } from './factory'
 import {
@@ -28,16 +29,14 @@ import {
   stopMihomoTraffic,
   stopMihomoLogs,
   stopMihomoMemory,
-  patchMihomoConfig
+  mihomoVersion
 } from './mihomoApi'
 import chokidar from 'chokidar'
 import { readFile, rm, writeFile } from 'fs/promises'
 import { promisify } from 'util'
-import { mainWindow } from '..'
 import path from 'path'
 import os from 'os'
 import { createWriteStream, existsSync } from 'fs'
-import { uploadRuntimeConfig } from '../resolve/gistApi'
 import { startMonitor } from '../resolve/trafficMonitor'
 import { safeShowErrorBox } from '../utils/init'
 import i18next from '../../shared/i18n'
@@ -52,8 +51,6 @@ chokidar.watch(path.join(mihomoCoreDir(), 'meta-update'), {}).on('unlinkDir', as
   }
 })
 
-export const mihomoIpcPath =
-  process.platform === 'win32' ? '\\\\.\\pipe\\MihomoParty\\mihomo' : '/tmp/mihomo-party.sock'
 const ctlParam = process.platform === 'win32' ? '-ext-ctl-pipe' : '-ext-ctl-unix'
 
 let setPublicDNSTimer: NodeJS.Timeout | null = null
@@ -72,7 +69,6 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
     disableSystemCA = false,
     skipSafePathCheck = false
   } = await getAppConfig()
-  const { 'log-level': logLevel } = await getControledMihomoConfig()
   if (existsSync(path.join(dataDir(), 'core.pid'))) {
     const pid = parseInt(await readFile(path.join(dataDir(), 'core.pid'), 'utf-8'))
     try {
@@ -139,50 +135,42 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
   })
   child.stdout?.pipe(stdout)
   child.stderr?.pipe(stderr)
+  try {
+    await waitForCoreReady()
+    await managerLogger.info('Core API is ready, starting background services.')
+    await startMihomoTraffic()
+    await startMihomoConnections()
+    await startMihomoLogs()
+    await startMihomoMemory()
+    retry = 10
+    return [Promise.resolve()]
+  } catch (error) {
+    await managerLogger.error('Core failed to start or API not responding.', error)
+    await stopCore() // Stop the failed core process
+    throw error // Re-throw the error to be caught by the caller
+  }
+}
+
+async function waitForCoreReady(timeoutMs = 15000): Promise<void> {
+  const startTime = Date.now()
+  const pollInterval = 1000 // ms
+
   return new Promise((resolve, reject) => {
-    child.stdout?.on('data', async (data) => {
-      const str = data.toString()
-      if (str.includes('configure tun interface: operation not permitted')) {
-        patchControledMihomoConfig({ tun: { enable: false } })
-        mainWindow?.webContents.send('controledMihomoConfigUpdated')
-        ipcMain.emit('updateTrayMenu')
-        reject(i18next.t('tun.error.tunPermissionDenied'))
+    const poll = setInterval(async () => {
+      if (Date.now() - startTime > timeoutMs) {
+        clearInterval(poll)
+        reject(new Error(`Core API did not respond within ${timeoutMs / 1000}s.`))
+        return
       }
 
-      if ((process.platform !== 'win32' && str.includes('External controller unix listen error')) ||
-        (process.platform === 'win32' && str.includes('External controller pipe listen error'))
-      ) {
-        reject(i18next.t('mihomo.error.externalControllerListenError'))
+      try {
+        await mihomoVersion()
+        clearInterval(poll)
+        resolve()
+      } catch (error) {
+        // Ignore connection errors and keep polling
       }
-
-      if (
-        (process.platform !== 'win32' && str.includes('RESTful API unix listening at')) ||
-        (process.platform === 'win32' && str.includes('RESTful API pipe listening at'))
-      ) {
-        resolve([
-          new Promise((resolve) => {
-            child.stdout?.on('data', async (data) => {
-              if (data.toString().toLowerCase().includes('start initial compatible provider default')) {
-                try {
-                  mainWindow?.webContents.send('groupsUpdated')
-                  mainWindow?.webContents.send('rulesUpdated')
-                  await uploadRuntimeConfig()
-                } catch {
-                  // ignore
-                }
-                await patchMihomoConfig({ 'log-level': logLevel })
-                resolve()
-              }
-            })
-          })
-        ])
-        await startMihomoTraffic()
-        await startMihomoConnections()
-        await startMihomoLogs()
-        await startMihomoMemory()
-        retry = 10
-      }
-    })
+    }, pollInterval)
   })
 }
 

--- a/src/main/core/mihomoApi.ts
+++ b/src/main/core/mihomoApi.ts
@@ -6,7 +6,7 @@ import { tray } from '../resolve/tray'
 import { calcTraffic } from '../utils/calc'
 import { getRuntimeConfig } from './factory'
 import { floatingWindow } from '../resolve/floatingWindow'
-import { mihomoIpcPath } from './manager'
+import { mihomoIpcPath } from '../utils/dirs'
 
 let axiosIns: AxiosInstance = null!
 let mihomoTrafficWs: WebSocket | null = null

--- a/src/main/utils/dirs.ts
+++ b/src/main/utils/dirs.ts
@@ -158,3 +158,6 @@ export function coreLogPath(): string {
   const name = `core-${year}-${month}-${day}`
   return path.join(logDir(), `${name}.log`)
 }
+
+export const mihomoIpcPath =
+  process.platform === 'win32' ? '\\\\.\\pipe\\MihomoParty\\mihomo' : '/tmp/mihomo-party.sock'

--- a/src/main/utils/init.ts
+++ b/src/main/utils/init.ts
@@ -324,9 +324,6 @@ async function migration(): Promise<void> {
       'external-controller-pipe': undefined
     })
   }
-  if (externalController === undefined) {
-    await patchControledMihomoConfig({ 'external-controller': '' })
-  }
   if (!showFloatingWindow && disableTray) {
     await patchAppConfig({ disableTray: false })
   }

--- a/src/main/utils/template.ts
+++ b/src/main/utils/template.ts
@@ -59,8 +59,8 @@ export const defaultControledMihomoConfig: Partial<IMihomoConfig> = {
   'tproxy-port': 0,
   'allow-lan': false,
   'unified-delay': true,
-  'tcp-concurrent': false,
-  'log-level': 'info',
+  'tcp-concurrent': true,
+  'log-level': 'warning',
   'find-process-mode': 'strict',
   'bind-address': '*',
   'lan-allowed-ips': ['0.0.0.0/0', '::/0'],
@@ -80,16 +80,17 @@ export const defaultControledMihomoConfig: Partial<IMihomoConfig> = {
   },
   dns: {
     enable: true,
-    ipv6: false,
+    ipv6: true,
     'enhanced-mode': 'fake-ip',
     'fake-ip-range': '198.18.0.1/16',
-    'fake-ip-filter': ['*', '+.lan', '+.local', 'time.*.com', 'ntp.*.com', '+.market.xiaomi.com'],
+    'fake-ip-filter': ['+.lan', '+.local', '+.arpa', 'time.*.com', 'ntp.*.com', '+.market.xiaomi.com', 'localhost.ptlogin2.qq.com', '+.msftncsi.com', 'www.msftconnecttest.com'],
+    'fake-ip-filter-mode': 'blacklist',
     'use-hosts': false,
     'use-system-hosts': false,
     'respect-rules': false,
-    'default-nameserver': ['tls://223.5.5.5'],
-    nameserver: ['https://doh.pub/dns-query', 'https://dns.alidns.com/dns-query'],
-    'proxy-server-nameserver': ['https://doh.pub/dns-query', 'https://dns.alidns.com/dns-query'],
+    'default-nameserver': ['system', '223.6.6.6', '8.8.8.8', '2400:3200::1', '2001:4860:4860::8888'],
+    nameserver: ['8.8.8.8', 'https://doh.pub/dns-query', 'https://dns.alidns.com/dns-query'],
+    'proxy-server-nameserver': ['https://doh.pub/dns-query', 'https://dns.alidns.com/dns-query', 'tls://223.5.5.5'],
     'direct-nameserver': [],
     fallback: [],
     'fallback-filter': {
@@ -137,10 +138,10 @@ export const defaultControledMihomoConfig: Partial<IMihomoConfig> = {
   'geo-update-interval': 24,
   'geodata-mode': false,
   'geox-url': {
-    geoip: 'https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip-lite.dat',
-    geosite: 'https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat',
-    mmdb: 'https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.metadb',
-    asn: 'https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/GeoLite2-ASN.mmdb'
+    geoip: 'https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip-lite.dat',
+    geosite: 'https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat',
+    mmdb: 'https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geoip.metadb',
+    asn: 'https://cdn.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/GeoLite2-ASN.mmdb'
   }
 }
 

--- a/src/renderer/src/pages/dns.tsx
+++ b/src/renderer/src/pages/dns.tsx
@@ -17,25 +17,30 @@ const DNS: React.FC = () => {
   const { dns, hosts } = controledMihomoConfig || {}
   const {
     enable = true,
-    ipv6 = false,
+    ipv6 = true,
     'fake-ip-range': fakeIPRange = '198.18.0.1/16',
     'fake-ip-filter': fakeIPFilter = [
-      '*',
       '+.lan',
       '+.local',
+      '+.arpa',
       'time.*.com',
       'ntp.*.com',
-      '+.market.xiaomi.com'
+      '+.market.xiaomi.com',
+      'localhost.ptlogin2.qq.com',
+      '+.msftncsi.com',
+      'www.msftconnecttest.com'
     ],
+    'fake-ip-filter-mode': fakeIPFilterMode = 'blacklist',
     'enhanced-mode': enhancedMode = 'fake-ip',
     'use-hosts': useHosts = false,
     'use-system-hosts': useSystemHosts = false,
     'respect-rules': respectRules = false,
-    'default-nameserver': defaultNameserver = ['tls://223.5.5.5'],
-    nameserver = ['https://doh.pub/dns-query', 'https://dns.alidns.com/dns-query'],
+    'default-nameserver': defaultNameserver = ['system', '223.6.6.6', '8.8.8.8', '2400:3200::1', '2001:4860:4860::8888'],
+    nameserver = ['8.8.8.8', 'https://doh.pub/dns-query', 'https://dns.alidns.com/dns-query'],
     'proxy-server-nameserver': proxyServerNameserver = [
       'https://doh.pub/dns-query',
-      'https://dns.alidns.com/dns-query'
+      'https://dns.alidns.com/dns-query',
+      'tls://223.5.5.5'
     ],
     'direct-nameserver': directNameserver = [],
     fallback = [],
@@ -54,6 +59,7 @@ const DNS: React.FC = () => {
     enhancedMode,
     fakeIPRange,
     fakeIPFilter,
+    fakeIPFilterMode,
     useSystemHosts,
     respectRules,
     defaultNameserver,
@@ -61,10 +67,10 @@ const DNS: React.FC = () => {
     proxyServerNameserver,
     directNameserver,
     fallback,
-    fallbackGeoip: fallbackFilter?.geoip || true,
-    fallbackGeoipCode: fallbackFilter?.['geoip-code'] || 'CN',
-    fallbackIpcidr: fallbackFilter?.ipcidr || ['240.0.0.0/4', '0.0.0.0/32'],
-    fallbackDomain: fallbackFilter?.domain || ['+.google.com', '+.facebook.com', '+.youtube.com'],
+    fallbackGeoip: fallbackFilter.geoip,
+    fallbackGeoipCode: fallbackFilter['geoip-code'],
+    fallbackIpcidr: fallbackFilter.ipcidr,
+    fallbackDomain: fallbackFilter.domain,
     useNameserverPolicy,
     nameserverPolicy: Object.entries(nameserverPolicy || {}).map(([domain, value]) => ({
       domain,

--- a/src/renderer/src/pages/mihomo.tsx
+++ b/src/renderer/src/pages/mihomo.tsx
@@ -49,7 +49,7 @@ const Mihomo: React.FC = () => {
     secret,
     authentication = [],
     'skip-auth-prefixes': skipAuthPrefixes = ['127.0.0.1/32', '::1/128'],
-    'log-level': logLevel = 'info',
+    'log-level': logLevel = 'warning',
     'find-process-mode': findProcessMode = 'strict',
     'allow-lan': allowLan,
     'lan-allowed-ips': lanAllowedIps = ['0.0.0.0/0', '::/0'],

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -354,7 +354,12 @@ interface IMihomoDNSConfig {
   'default-nameserver'?: string[]
   nameserver?: string[]
   fallback?: string[]
-  'fallback-filter'?: { [key: string]: boolean | string | string[] }
+  'fallback-filter'?: {
+    geoip?: boolean
+    'geoip-code'?: string
+    ipcidr?: string[]
+    domain?: string[]
+  }
   'proxy-server-nameserver'?: string[]
   'direct-nameserver'?: string[]
   'direct-nameserver-follow-policy'?: boolean


### PR DESCRIPTION
## Summary

- 优化DNS配置、默认开启 `tcp-concurrent` 等配置提升性能及稳定性
- 默认开启ipv6，默认日志级别为警告
- 调整默认的geox-url地址采用cnd地址提升下载成功率
- 修复运行时配置log-level总是info的问题
- 优化核心启动流程，使用API轮询替代日志解析

重构配置管理，提升启动稳定性

## 主要改动

### 1. 修复运行时日志log-level总是info，并核心启动流程优化
- **问题**: config-viewer组件显示的log-level总是"info"，不反映用户通过"内核设置"的实际更改
- **改进**:
  - 实现`waitForCoreReady()`使用API轮询检测核心就绪状态
  - 移除复杂的日志解析逻辑，提升启动可靠性
  - 优化错误处理和超时机制

### 2. 代码架构改进
- 重构mihomoIpcPath到dirs.ts统一管理
- 清理不必要的配置强制覆盖逻辑
- 简化启动检测机制

## 测试计划

- [x] 验证运行时配置显示正确反映log-level更改
- [x] 测试核心启动流程的稳定性
- [x] 确认API调用正常工作
- [x] 验证配置更改后的实时同步