### PR TITLE
fix: remove envs introduced in v1.7.0 to make Linux TUN work properly

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -86,11 +86,7 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
     core = 'mihomo',
     autoSetDNS = true,
     diffWorkDir = false,
-    mihomoCpuPriority = 'PRIORITY_NORMAL',
-    disableLoopbackDetector = false,
-    disableEmbedCA = false,
-    disableSystemCA = false,
-    skipSafePathCheck = false
+    mihomoCpuPriority = 'PRIORITY_NORMAL'
   } = await getAppConfig()
   const { 'log-level': logLevel } = await getControledMihomoConfig()
   if (existsSync(path.join(dataDir(), 'core.pid'))) {
@@ -135,19 +131,13 @@ export async function startCore(detached = false): Promise<Promise<void>[]> {
   // 内核日志输出到独立的 core-日期.log 文件
   const stdout = createWriteStream(coreLogPath(), { flags: 'a' })
   const stderr = createWriteStream(coreLogPath(), { flags: 'a' })
-  const env = {
-    DISABLE_LOOPBACK_DETECTOR: String(disableLoopbackDetector),
-    DISABLE_EMBED_CA: String(disableEmbedCA),
-    DISABLE_SYSTEM_CA: String(disableSystemCA),
-    SKIP_SAFE_PATH_CHECK: String(skipSafePathCheck)
-  }
+  
   child = spawn(
     corePath,
     ['-d', diffWorkDir ? mihomoProfileWorkDir(current) : mihomoWorkDir(), ctlParam, dynamicIpcPath],
     {
       detached: detached,
-      stdio: detached ? 'ignore' : undefined,
-      env: env
+      stdio: detached ? 'ignore' : undefined
     }
   )
   if (process.platform === 'win32' && child.pid) {
@@ -431,15 +421,12 @@ export async function quitWithoutCore(): Promise<void> {
 async function checkProfile(): Promise<void> {
   const {
     core = 'mihomo',
-    diffWorkDir = false,
-    skipSafePathCheck = false
+    diffWorkDir = false
   } = await getAppConfig()
   const { current } = await getProfileConfig()
   const corePath = mihomoCorePath(core)
   const execFilePromise = promisify(execFile)
-  const env = {
-    SKIP_SAFE_PATH_CHECK: String(skipSafePathCheck)
-  }
+  
   try {
     await execFilePromise(corePath, [
       '-t',
@@ -447,7 +434,7 @@ async function checkProfile(): Promise<void> {
       diffWorkDir ? mihomoWorkConfigPath(current) : mihomoWorkConfigPath('work'),
       '-d',
       mihomoTestDir()
-    ], { env })
+    ])
   } catch (error) {
     await managerLogger.error('Profile check failed', error)
 

--- a/src/main/utils/template.ts
+++ b/src/main/utils/template.ts
@@ -25,11 +25,7 @@ export const defaultConfig: IAppConfig = {
   controlSniff: true,
   floatingWindowCompatMode: true,
   disableHardwareAcceleration: false,
-  disableLoopbackDetector: false,
   hideConnectionCardWave: false,
-  disableEmbedCA: false,
-  disableSystemCA: false,
-  skipSafePathCheck: false,
   nameserverPolicy: {},
   siderOrder: [
     'sysproxy',

--- a/src/renderer/src/pages/mihomo.tsx
+++ b/src/renderer/src/pages/mihomo.tsx
@@ -42,11 +42,8 @@ const Mihomo: React.FC = () => {
     smartCoreCollectData = false,
     smartCoreStrategy = 'sticky-sessions',
     maxLogDays = 7,
-    sysProxy,
-    disableLoopbackDetector,
-    disableEmbedCA,
-    disableSystemCA,
-    skipSafePathCheck } = appConfig || {}
+    sysProxy 
+  } = appConfig || {}
   const { controledMihomoConfig, patchControledMihomoConfig } = useControledMihomoConfig()
 
   interface WebUIPanel {
@@ -1130,42 +1127,7 @@ const Mihomo: React.FC = () => {
               }}
             />
           </SettingItem>
-          <SettingItem title={t('mihomo.disableLoopbackDetector')} divider>
-            <Switch
-              size="sm"
-              isSelected={disableLoopbackDetector}
-              onValueChange={(v) => {
-                handleConfigChangeWithRestart('disableLoopbackDetector', v)
-              }}
-            />
-          </SettingItem>
-          <SettingItem title={t('mihomo.skipSafePathCheck')} divider>
-            <Switch
-              size="sm"
-              isSelected={skipSafePathCheck}
-              onValueChange={(v) => {
-                handleConfigChangeWithRestart('skipSafePathCheck', v)
-              }}
-            />
-          </SettingItem>
-          <SettingItem title={t('mihomo.disableEmbedCA')} divider>
-            <Switch
-              size="sm"
-              isSelected={disableEmbedCA}
-              onValueChange={(v) => {
-                handleConfigChangeWithRestart('disableEmbedCA', v)
-              }}
-            />
-          </SettingItem>
-          <SettingItem title={t('mihomo.disableSystemCA')} divider>
-            <Switch
-              size="sm"
-              isSelected={disableSystemCA}
-              onValueChange={(v) => {
-                handleConfigChangeWithRestart('disableSystemCA', v)
-              }}
-            />
-          </SettingItem>
+
           <SettingItem title={t('mihomo.logRetentionDays')} divider>
             <Input
               size="sm"

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -223,10 +223,6 @@ interface IAppConfig {
   smartCoreUseLightGBM: boolean
   smartCoreCollectData: boolean
   smartCoreStrategy: 'sticky-sessions' | 'round-robin'
-  disableLoopbackDetector: boolean
-  disableEmbedCA: boolean
-  disableSystemCA: boolean
-  skipSafePathCheck: boolean
   proxyDisplayMode: 'simple' | 'full'
   proxyDisplayOrder: 'default' | 'delay' | 'name'
   profileDisplayDate?: 'expire' | 'update'


### PR DESCRIPTION
closes: #939
closes: #1165
maybe related: #1231

自 `v1.7.0` 起，所有版本的 `mihomo/clash-party` 的 tun 模式都无法在 linux 中正常工作（具体原因以及 workaround 见 https://github.com/xishang0128/sparkle/issues/37#issuecomment-3218263612 ，也许对后续工作有用）。`v1.6.0` tun 模式则在 linux 中工作正常（我使用至今）。

`v1.7.0` 相较 `v1.6.0` 进行了大量的 UI 重构以及部分功能新增，但 mihomo 内核和 `v1.6.0` 版本一致，均为 `v1.19.1`，因此可以看到问题并不出在内核上，而是 GUI 程序出现了问题。经过排查 `v1.7.0` 相较 `v1.6.0` 多了如下 4 个环境变量：

https://github.com/mihomo-party-org/clash-party/blob/2bf54446df75aff12bbfa239b9d4bdeb13a1fdd8/src/main/core/manager.ts#L90-L93

我在 `v1.7.0` 、 `v1.8.5`、  `v1.8.8` 这三个版本中将所有涉及这 4 个环境变量的地方都删除掉后构建，在 fedora linux 42 上测试 tun 模式功能均恢复正常，且不影响其他功能（当然，这4个环境变量对应的选项/功能被移除）。

只是现在不知道是这四个环境变量中的哪些个影响了 linux 中的 tun 模式，为了使 linux tun mode 可用，暂时全部移除。后续恢复这些环境变量对应的功能时需要逐个排查。