### PR TITLE
fix: postuninst & postinst script in Linux

### DIFF
--- a/build/linux/postinst
+++ b/build/linux/postinst
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-if type update-alternatives 2>/dev/null >&1; then
+set -e
+
+if type update-alternatives >/dev/null 2>&1; then
     # Remove previous link if it doesn't use update-alternatives
-    if [ -L '/usr/bin/mihomo-party' -a -e '/usr/bin/mihomo-party' -a "`readlink '/usr/bin/mihomo-party'`" != '/etc/alternatives/mihomo-party' ]; then
+    if [ -L '/usr/bin/mihomo-party' ] && [ -e '/usr/bin/mihomo-party' ] && [ "$(readlink '/usr/bin/mihomo-party')" != '/etc/alternatives/mihomo-party' ]; then
         rm -f '/usr/bin/mihomo-party'
     fi
     update-alternatives --install '/usr/bin/mihomo-party' 'mihomo-party' '/opt/mihomo-party/mihomo-party' 100 || ln -sf '/opt/mihomo-party/mihomo-party' '/usr/bin/mihomo-party'
@@ -10,10 +12,11 @@ else
     ln -sf '/opt/mihomo-party/mihomo-party' '/usr/bin/mihomo-party'
 fi
 
-chmod 4755 '/opt/mihomo-party/chrome-sandbox' || true
-chmod +sx /opt/mihomo-party/resources/sidecar/mihomo
-chmod +sx /opt/mihomo-party/resources/sidecar/mihomo-alpha
-chmod +sx /opt/mihomo-party/resources/sidecar/mihomo-smart
+chmod 4755 '/opt/mihomo-party/chrome-sandbox' 2>/dev/null || true
+
+chmod +sx /opt/mihomo-party/resources/sidecar/mihomo 2>/dev/null || true
+chmod +sx /opt/mihomo-party/resources/sidecar/mihomo-alpha 2>/dev/null || true
+chmod +sx /opt/mihomo-party/resources/sidecar/mihomo-smart 2>/dev/null || true
 
 if hash update-mime-database 2>/dev/null; then
     update-mime-database /usr/share/mime || true

--- a/build/linux/postuninst
+++ b/build/linux/postuninst
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+case "$1" in
+  remove|purge|0)
+    if type update-alternatives >/dev/null 2>&1; then
+        update-alternatives --remove 'mihomo-party' '/opt/mihomo-party/mihomo-party' 2>/dev/null || true
+    fi
+    
+    [ -L '/usr/bin/mihomo-party' ] && rm -f '/usr/bin/mihomo-party'
+
+    if hash update-mime-database 2>/dev/null; then
+      update-mime-database /usr/share/mime || true
+    fi
+
+    if hash update-desktop-database 2>/dev/null; then
+        update-desktop-database /usr/share/applications || true
+    fi
+    ;;
+  *)
+    # others
+    ;;
+esac

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -68,7 +68,9 @@ linux:
   artifactName: clash-party-linux-${version}-${arch}.${ext}
 deb:
   afterInstall: 'build/linux/postinst'
+  afterRemove: 'build/linux/postuninst'
 rpm:
   afterInstall: 'build/linux/postinst'
+  afterRemove: 'build/linux/postuninst'
 npmRebuild: true
 publish: []


### PR DESCRIPTION
1. 重构了在 linux 中安装时的 postinst 脚本：使其语法更现代，同时隐藏不必要的输出；

2. 添加了在 linux 中卸载时的 postuninst 脚本：之前，项目没有编写在 linux 中的应用卸载时的脚本，所以似乎会自动生成，以 RPM package 为例，生成的脚本如下：

_postuninstall scriptlet (using /bin/sh)_
```
#!/bin/bash

# Delete the link to the binary
if type update-alternatives >/dev/null 2>&1; then
    update-alternatives --remove 'mihomo-party' '/usr/bin/mihomo-party'
else
    rm -f '/usr/bin/mihomo-party'
fi

APPARMOR_PROFILE_DEST='/etc/apparmor.d/mihomo-party'

# Remove apparmor profile.
if [ -f "$APPARMOR_PROFILE_DEST" ]; then
  rm -f "$APPARMOR_PROFILE_DEST"
fi
```
首先，该脚本无法正确删除 `/usr/bin/mihomo-party` 以及 `/etc/alternatives/mihomo-party` 这两个链接；其次，`/etc/apparmor.d/` 目录并不存在。因此该脚本是无效的。

已在 fedora linux 42 中构建并测试，安装、卸载都能很好地处理符号链接了。