### PR TITLE
fix: prevent event propagation on button press in proxies page

### DIFF
--- a/src/renderer/src/pages/proxies.tsx
+++ b/src/renderer/src/pages/proxies.tsx
@@ -357,7 +357,8 @@ const Proxies: React.FC = () => {
                   variant="light"
                   size="sm"
                   isIconOnly
-                  onPress={() => {
+                  onPress={(e) => {
+                    e.stopPropagation()
                     if (!isOpen[index]) {
                       setIsOpen((prev) => {
                         const newOpen = [...prev]
@@ -388,7 +389,8 @@ const Proxies: React.FC = () => {
                   isLoading={delaying[index]}
                   size="sm"
                   isIconOnly
-                  onPress={() => {
+                  onPress={(e) => {
+                    e.stopPropagation()
                     onGroupDelay(index)
                   }}
                 >


### PR DESCRIPTION
### 问题描述
在代理页面中点击按钮时会导致事件传播，触发父元素的处理程序。这导致用户点击代理组中的展开/折叠按钮或延迟测试按钮时出现意外行为。

### 更改内容
- 在 `src/renderer/src/pages/proxies.tsx` 的两个按钮 `onPress` 处理程序中添加了 `e.stopPropagation()`：
  1. **展开/折叠按钮**：防止切换代理组可见性时按钮点击事件传播到父元素
  2. **延迟测试按钮**：防止触发组延迟测试时按钮点击事件传播

### 技术细节
- 修改了 `onPress` 回调函数，使其接受事件参数 (`e`)
- 在每个处理程序的开头调用 `e.stopPropagation()` 以阻止事件冒泡到 DOM 树上层

### 影响
- 通过确保按钮仅触发其预期操作来改善用户体验
- 防止意外触发父元素的点击处理程序
- 无破坏性更改或 API 修改

---

是的，我觉得肯定有人手快，想多点几次，我自己就是）