### PR TITLE
fix: enable Smart Core button initial state

### DIFF
--- a/src/renderer/src/pages/mihomo.tsx
+++ b/src/renderer/src/pages/mihomo.tsx
@@ -36,7 +36,7 @@ const Mihomo: React.FC = () => {
   const {
     core = 'mihomo',
     specificVersion,
-    enableSmartCore = true,
+    enableSmartCore = false,
     enableSmartOverride = true,
     smartCoreUseLightGBM = false,
     smartCoreCollectData = false,
@@ -414,7 +414,7 @@ const Mihomo: React.FC = () => {
             </SettingItem>
 
             {/* Smart 覆写开关 */}
-            {enableSmartCore && (
+            {enableSmartCore && core === 'mihomo-smart' && (
               <SettingItem
                 title={
                   <div className="flex items-center gap-2">


### PR DESCRIPTION
内核设置页的初始状态下，设置了 `启用 Smart 内核` ，但初始设置的内核仍然是 `mihomo`：

https://github.com/mihomo-party-org/clash-party/blob/f61072c3094a6b36e22fa0670120737806cf1eae/src/renderer/src/pages/mihomo.tsx#L37

<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/6a7a140f-dcf0-4ea9-b1ea-f533f12c69d6" />

现在已将默认情况下 `启用 Smart 内核` 设置为 false，和初始设置的内核保持统一。同时，修复了 `Smart 覆写开关` 的显示逻辑。