### PR TITLE
fix: change deb/rpm install path from "mihomo-party" to "clash-party"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,7 +266,7 @@ jobs:
         run: |
           pnpm install
           pnpm add @mihomo-party/sysproxy-linux-${{ matrix.arch }}-gnu
-          sed -i "s/productName: Clash Party/productName: mihomo-party/" electron-builder.yml
+          sed -i "s/productName: Clash Party/productName: clash-party/" electron-builder.yml
       - name: Update Version for Dev Build
         if: github.event_name == 'workflow_dispatch'
         env:

--- a/build/linux/postinst
+++ b/build/linux/postinst
@@ -4,19 +4,19 @@ set -e
 
 if type update-alternatives >/dev/null 2>&1; then
     # Remove previous link if it doesn't use update-alternatives
-    if [ -L '/usr/bin/mihomo-party' ] && [ -e '/usr/bin/mihomo-party' ] && [ "$(readlink '/usr/bin/mihomo-party')" != '/etc/alternatives/mihomo-party' ]; then
-        rm -f '/usr/bin/mihomo-party'
+    if [ -L '/usr/bin/clash-party' ] && [ -e '/usr/bin/clash-party' ] && [ "$(readlink '/usr/bin/clash-party')" != '/etc/alternatives/clash-party' ]; then
+        rm -f '/usr/bin/clash-party'
     fi
-    update-alternatives --install '/usr/bin/mihomo-party' 'mihomo-party' '/opt/mihomo-party/mihomo-party' 100 || ln -sf '/opt/mihomo-party/mihomo-party' '/usr/bin/mihomo-party'
+    update-alternatives --install '/usr/bin/clash-party' 'clash-party' '/opt/clash-party/mihomo-party' 100 || ln -sf '/opt/clash-party/mihomo-party' '/usr/bin/clash-party'
 else
-    ln -sf '/opt/mihomo-party/mihomo-party' '/usr/bin/mihomo-party'
+    ln -sf '/opt/clash-party/mihomo-party' '/usr/bin/clash-party'
 fi
 
-chmod 4755 '/opt/mihomo-party/chrome-sandbox' 2>/dev/null || true
+chmod 4755 '/opt/clash-party/chrome-sandbox' 2>/dev/null || true
 
-chmod +sx /opt/mihomo-party/resources/sidecar/mihomo 2>/dev/null || true
-chmod +sx /opt/mihomo-party/resources/sidecar/mihomo-alpha 2>/dev/null || true
-chmod +sx /opt/mihomo-party/resources/sidecar/mihomo-smart 2>/dev/null || true
+chmod +sx /opt/clash-party/resources/sidecar/mihomo 2>/dev/null || true
+chmod +sx /opt/clash-party/resources/sidecar/mihomo-alpha 2>/dev/null || true
+chmod +sx /opt/clash-party/resources/sidecar/mihomo-smart 2>/dev/null || true
 
 if hash update-mime-database 2>/dev/null; then
     update-mime-database /usr/share/mime || true

--- a/build/linux/postuninst
+++ b/build/linux/postuninst
@@ -3,10 +3,10 @@
 case "$1" in
   remove|purge|0)
     if type update-alternatives >/dev/null 2>&1; then
-        update-alternatives --remove 'mihomo-party' '/opt/mihomo-party/mihomo-party' 2>/dev/null || true
+        update-alternatives --remove 'clash-party' '/opt/clash-party/mihomo-party' 2>/dev/null || true
     fi
     
-    [ -L '/usr/bin/mihomo-party' ] && rm -f '/usr/bin/mihomo-party'
+    [ -L '/usr/bin/clash-party' ] && rm -f '/usr/bin/clash-party'
 
     if hash update-mime-database 2>/dev/null; then
       update-mime-database /usr/share/mime || true


### PR DESCRIPTION
closes: #1135

GitHub Actions 中，deb/rpm 的 release 在 Ubuntu 中构建，安装目录由 `electron-builder.yml` 中的 `productName` 决定，改为 `clash-party` 即可让安装目录变为 `/opt/clash-party`。

同步修改 `postinst` 和 `postuninst` 脚本。