### PR TITLE
fix: smartcore initial state in template.ts

### DIFF
--- a/src/main/utils/template.ts
+++ b/src/main/utils/template.ts
@@ -1,6 +1,6 @@
 export const defaultConfig: IAppConfig = {
   core: 'mihomo',
-  enableSmartCore: true,
+  enableSmartCore: false,
   enableSmartOverride: true,
   smartCoreUseLightGBM: false,
   smartCoreCollectData: false,


### PR DESCRIPTION
在 PR #1299 中，我同步了初始设置下，实际使用的内核和智能内核启用开关的状态，但今天构建了一下测试后发现问题并没完全解决。原因在于没有修改 `template.ts`，在 `src/renderer/src/pages` 里修改的初始值是没效果的，疏忽了...🙏