### PR TITLE
Revert "fix: prevent event propagation on button press in proxies page"

### DIFF
--- a/src/renderer/src/pages/proxies.tsx
+++ b/src/renderer/src/pages/proxies.tsx
@@ -357,8 +357,7 @@ const Proxies: React.FC = () => {
                   variant="light"
                   size="sm"
                   isIconOnly
-                  onPress={(e) => {
-                    e.stopPropagation()
+                  onPress={() => {
                     if (!isOpen[index]) {
                       setIsOpen((prev) => {
                         const newOpen = [...prev]
@@ -389,8 +388,7 @@ const Proxies: React.FC = () => {
                   isLoading={delaying[index]}
                   size="sm"
                   isIconOnly
-                  onPress={(e) => {
-                    e.stopPropagation()
+                  onPress={() => {
                     onGroupDelay(index)
                   }}
                 >


### PR DESCRIPTION
This reverts commit b272634c11e6ee93493b01e9b9a41941d5d433a1.

经过本地构建测试，这个 commit 会使得代理页的 `locate` 按钮和 `test` 按钮变得不可用。revert 后恢复正常。