### PR TITLE
fix: handle non-array response when fetching Mihomo tags

### DIFF
--- a/src/renderer/src/pages/mihomo.tsx
+++ b/src/renderer/src/pages/mihomo.tsx
@@ -324,9 +324,10 @@ const Mihomo: React.FC = () => {
     setLoadingTags(true)
     try {
       const data = await fetchMihomoTags(forceRefresh)
-      setTags(data)
+      setTags(Array.isArray(data) ? data : [])
     } catch (error) {
       console.error('Failed to fetch tags:', error)
+      setTags([])
       alert(t('mihomo.error.fetchTagsFailed'))
     } finally {
       setLoadingTags(false)


### PR DESCRIPTION
fix #1430 