### PR TITLE
fix: exclude .build-id files from RPM package to prevent conflicts

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -72,5 +72,8 @@ deb:
 rpm:
   afterInstall: 'build/linux/postinst'
   afterRemove: 'build/linux/postuninst'
+  fpm:
+    - '--rpm-rpmbuild-define'
+    - '_build_id_links none'
 npmRebuild: true
 publish: []


### PR DESCRIPTION
fix #1470 #687 