### PR TITLE
feat: subscription timeout settings & initialization optimization  & subscription update logic efficiency

### DIFF
--- a/src/main/config/profile.ts
+++ b/src/main/config/profile.ts
@@ -217,99 +217,79 @@ async function fetchAndValidateSubscription(options: FetchOptions): Promise<Fetc
 }
 
 export async function createProfile(item: Partial<IProfileItem>): Promise<IProfileItem> {
-  const id = item.id || new Date().getTime().toString(16)
-  const newItem = {
+  const id = item.id || Date.now().toString(16);
+
+  const newItem: IProfileItem = {
     id,
     name: item.name || (item.type === 'remote' ? 'Remote File' : 'Local File'),
-    type: item.type,
+    type: item.type!,
     url: item.url,
-    substore: item.substore || false,
+    substore: !!item.substore,
     interval: item.interval || 0,
     override: item.override || [],
-    useProxy: item.useProxy || false,
-    allowFixedInterval: item.allowFixedInterval || false,
+    useProxy: !!item.useProxy,
+    allowFixedInterval: !!item.allowFixedInterval,
     autoUpdate: item.autoUpdate ?? false,
     authToken: item.authToken,
-    updated: new Date().getTime()
-  } as IProfileItem
+    updated: Date.now(),
+    updateTimeout: item.updateTimeout || 5
+  };
 
-  switch (newItem.type) {
-    case 'remote': {
-      const { userAgent, subscriptionTimeout = 30000 } = await getAppConfig()
-      const { 'mixed-port': mixedPort = 7890 } = await getControledMihomoConfig()
-      if (!item.url) throw new Error('Empty URL')
+  if (newItem.type === 'local') {
+    await setProfileStr(id, item.file || '');
+    return newItem;
+  }
 
-      const baseOptions: Omit<FetchOptions, 'useProxy' | 'timeout'> = {
-        url: item.url,
-        mixedPort,
-        userAgent: userAgent || `mihomo.party/v${app.getVersion()} (clash.meta)`,
-        authToken: item.authToken,
-        substore: newItem.substore || false
-      }
+  if (!item.url) throw new Error('Empty URL');
 
-      let result: FetchResult
-      let finalUseProxy = newItem.useProxy
+  const { userAgent, subscriptionTimeout = 30000 } = await getAppConfig();
+  const { 'mixed-port': mixedPort = 7890 } = await getControledMihomoConfig();
+  const userItemTimeoutMs = (newItem.updateTimeout || 5) * 1000;
 
-      if (newItem.useProxy) {
-        result = await fetchAndValidateSubscription({
-          ...baseOptions,
-          useProxy: true,
-          timeout: subscriptionTimeout
-        })
-      } else if (newItem.substore) {
-        // SubStore requests (especially collections) need more time as they fetch and merge multiple subscriptions
-        // Use the full subscriptionTimeout since SubStore is a local server and doesn't need smart fallback
-        result = await fetchAndValidateSubscription({
-          ...baseOptions,
-          useProxy: false,
-          timeout: subscriptionTimeout
-        })
-      } else {
-        const smartTimeout = 5000
-        try {
-          result = await fetchAndValidateSubscription({
-            ...baseOptions,
-            useProxy: false,
-            timeout: smartTimeout
-          })
-        } catch (directError) {
-          try {
-            result = await fetchAndValidateSubscription({
-              ...baseOptions,
-              useProxy: true,
-              timeout: smartTimeout
-            })
-            finalUseProxy = true
-          } catch {
-            throw directError
-          }
-        }
-      }
+  const baseOptions: Omit<FetchOptions, 'useProxy' | 'timeout'> = {
+    url: item.url,
+    mixedPort,
+    userAgent: userAgent || `mihomo.party/v${app.getVersion()} (clash.meta)`,
+    authToken: item.authToken,
+    substore: newItem.substore!
+  };
 
-      newItem.useProxy = finalUseProxy
-      const { data, headers } = result
+  const fetchSub = (useProxy: boolean, timeout: number) => 
+    fetchAndValidateSubscription({ ...baseOptions, useProxy, timeout });
 
-      if (headers['content-disposition'] && newItem.name === 'Remote File') {
-        newItem.name = parseFilename(headers['content-disposition'])
+  let result: FetchResult;
+  if (newItem.useProxy || newItem.substore) {
+    result = await fetchSub(newItem.useProxy!, userItemTimeoutMs);
+  } else {
+    try {
+      result = await fetchSub(false, userItemTimeoutMs);
+    } catch (directError) {
+      try {
+        // smart fallback 
+        result = await fetchSub(true, subscriptionTimeout);
+      } catch {
+        throw directError;
       }
-      if (headers['profile-web-page-url']) {
-        newItem.home = headers['profile-web-page-url']
-      }
-      if (headers['profile-update-interval'] && !item.allowFixedInterval) {
-        newItem.interval = parseInt(headers['profile-update-interval']) * 60
-      }
-      if (headers['subscription-userinfo']) {
-        newItem.extra = parseSubinfo(headers['subscription-userinfo'])
-      }
-      await setProfileStr(id, data)
-      break
-    }
-    case 'local': {
-      await setProfileStr(id, item.file || '')
-      break
     }
   }
-  return newItem
+
+  const { data, headers } = result;
+
+  if (headers['content-disposition'] && newItem.name === 'Remote File') {
+    newItem.name = parseFilename(headers['content-disposition']);
+  }
+  if (headers['profile-web-page-url']) {
+    newItem.home = headers['profile-web-page-url'];
+  }
+  if (headers['profile-update-interval'] && !newItem.allowFixedInterval) {
+    newItem.interval = parseInt(headers['profile-update-interval']) * 60;
+  }
+  if (headers['subscription-userinfo']) {
+    newItem.extra = parseSubinfo(headers['subscription-userinfo']);
+  }
+
+  await setProfileStr(id, data);
+  return newItem;
 }
 
 export async function getProfileStr(id: string | undefined): Promise<string> {

--- a/src/renderer/src/components/profiles/edit-info-modal.tsx
+++ b/src/renderer/src/components/profiles/edit-info-modal.tsx
@@ -104,6 +104,24 @@ const EditInfoModal: React.FC<Props> = (props) => {
                   placeholder={t('profiles.editInfo.authTokenPlaceholder')}
                 />
               </SettingItem>
+              <SettingItem title={t('profiles.editInfo.updateTimeout')}>
+                <Input
+                  size="sm"
+                  type="number"
+                  className={cn(inputWidth)}
+                  value={values.updateTimeout?.toString() ?? ''}
+                  onValueChange={(v) => {
+                    const val = parseInt(v)
+                    setValues({ ...values, updateTimeout: isNaN(val) ? undefined : val })
+                  }}
+                  placeholder="5"
+                  endContent={
+                    <div className="pointer-events-none flex items-center">
+                      <span className="text-default-400 text-small">s</span>
+                    </div>
+                  }
+                />
+              </SettingItem>
               <SettingItem title={t('profiles.editInfo.useProxy')}>
                 <Switch
                   size="sm"

--- a/src/renderer/src/hooks/use-profile-config.tsx
+++ b/src/renderer/src/hooks/use-profile-config.tsx
@@ -38,8 +38,21 @@ export const ProfileConfigProvider: React.FC<{ children: ReactNode }> = ({ child
 }
 
 const ProfileConfigContextWrapper: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const { config, mutate } = useConfig()
+  const { config: rawConfig, mutate } = useConfig()
   const { t } = useTranslation()
+
+  // Fix the missing default configuration values in the old version
+  const config = React.useMemo(() => {
+    if (!rawConfig) return undefined;
+    return {
+      ...rawConfig,
+      items: (rawConfig.items || []).map((item) => ({
+        ...item,
+        updateTimeout: 5,
+      })),
+    } as IProfileConfig;
+  }, [rawConfig]);
+
   const targetProfileId = useRef<string | null>(null)
   const pendingTask = useRef<Promise<void> | null>(null)
 

--- a/src/renderer/src/locales/en-US.json
+++ b/src/renderer/src/locales/en-US.json
@@ -471,6 +471,7 @@
   "profiles.editInfo.url": "Subscription URL",
   "profiles.editInfo.authToken": "Authorization Token",
   "profiles.editInfo.authTokenPlaceholder": "Bearer token or other auth header value",
+  "profiles.editInfo.updateTimeout": "Update Timeout",
   "profiles.editInfo.useProxy": "Use Proxy to Update",
   "profiles.editInfo.interval": "Upd. Interval",
   "profiles.editInfo.intervalPlaceholder": "e.g.: 30 or '0 * * * *'",

--- a/src/renderer/src/locales/fa-IR.json
+++ b/src/renderer/src/locales/fa-IR.json
@@ -447,6 +447,7 @@
   "profiles.editInfo.title": "ویرایش اطلاعات",
   "profiles.editInfo.name": "نام",
   "profiles.editInfo.url": "آدرس اشتراک",
+  "profiles.editInfo.updateTimeout": "زمان انتظار به‌روزرسانی",
   "profiles.editInfo.useProxy": "استفاده از پراکسی برای به‌روزرسانی",
   "profiles.editInfo.interval": "فاصله به‌روزرسانی",
   "profiles.editInfo.fixedInterval": "فاصله به‌روزرسانی ثابت",

--- a/src/renderer/src/locales/ru-RU.json
+++ b/src/renderer/src/locales/ru-RU.json
@@ -447,6 +447,7 @@
   "profiles.editInfo.title": "Редактировать информацию",
   "profiles.editInfo.name": "Имя",
   "profiles.editInfo.url": "URL подписки",
+  "profiles.editInfo.updateTimeout": "Таймаут обновления",
   "profiles.editInfo.useProxy": "Использовать прокси для обновления",
   "profiles.editInfo.interval": "Интервал обн.",
   "profiles.editInfo.fixedInterval": "Фиксированный интервал обновления",

--- a/src/renderer/src/locales/zh-CN.json
+++ b/src/renderer/src/locales/zh-CN.json
@@ -476,6 +476,7 @@
   "profiles.editInfo.url": "订阅地址",
   "profiles.editInfo.authToken": "授权令牌",
   "profiles.editInfo.authTokenPlaceholder": "Bearer token 或其他认证头值",
+  "profiles.editInfo.updateTimeout": "更新超时时间",
   "profiles.editInfo.useProxy": "使用代理更新",
   "profiles.editInfo.interval": "更新间隔",
   "profiles.editInfo.intervalPlaceholder": "例如：30 或 '0 * * * *'",

--- a/src/renderer/src/locales/zh-TW.json
+++ b/src/renderer/src/locales/zh-TW.json
@@ -476,6 +476,7 @@
   "profiles.editInfo.url": "訂閱地址",
   "profiles.editInfo.authToken": "授權令牌",
   "profiles.editInfo.authTokenPlaceholder": "Bearer token 或其他認證頭值",
+  "profiles.editInfo.updateTimeout": "更新逾時時間",
   "profiles.editInfo.useProxy": "使用代理更新",
   "profiles.editInfo.interval": "更新間隔",
   "profiles.editInfo.intervalPlaceholder": "例如：30 或 '0 * * * *'",

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -497,6 +497,7 @@ interface IProfileItem {
   allowFixedInterval?: boolean
   autoUpdate?: boolean
   authToken?: string
+  updateTimeout?: number
 }
 
 interface ISubStoreSub {


### PR DESCRIPTION
[Fix issues: subscriptions update timeout](https://github.com/mihomo-party-org/clash-party/issues/1541)

1. Add dedicated timeout config option for subscriptions
2. Improve subscription update logic efficiency
3. Fix missing config handling during initialization of legacy versions
4. Add updateTimeout property to IProfileItem interface
5. Localize profiles.editInfo.updateTimeout for en-US/fa-IR/ru-RU/zh-CN/zh-TW
