### PR TITLE
fix: badge not clickable

### DIFF
--- a/src/renderer/src/pages/connections.tsx
+++ b/src/renderer/src/pages/connections.tsx
@@ -479,7 +479,7 @@ const Connections: React.FC = () => {
             </span>
           </div>
           <Badge
-            className="mt-2"
+            className="app-nodrag pointer-events-none mt-2"
             color="primary"
             variant="flat"
             showOutline={false}


### PR DESCRIPTION
Fix the connections count badge disallows click the close button under it.