### PR TITLE
fix(macos): fix proxy-provider refresh failure due to root-owned files in work directory

### DIFF
--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -5,7 +5,7 @@ import { existsSync } from 'fs'
 import { app, powerMonitor } from 'electron'
 import { stopCore, cleanupCoreWatcher } from './core/manager'
 import { triggerSysProxy } from './sys/sysproxy'
-import { exePath } from './utils/dirs'
+import { exePath, mihomoWorkDir } from './utils/dirs'
 
 export function customRelaunch(): void {
   const script = `while kill -0 ${process.pid} 2>/dev/null; do
@@ -26,17 +26,38 @@ export async function fixUserDataPermissions(): Promise<void> {
   const userDataPath = app.getPath('userData')
   if (!existsSync(userDataPath)) return
 
+  const currentUid = process.getuid?.() || 0
+  if (currentUid === 0) return
+
+  const username = process.env.USER || process.env.LOGNAME
+  if (!username) return
+
+  const execPromise = promisify(exec)
+
   try {
     const stats = await stat(userDataPath)
-    const currentUid = process.getuid?.() || 0
+    if (stats.uid === 0) {
+      await execPromise(`chown -R "${username}:staff" "${userDataPath}"`)
+      await execPromise(`chmod -R u+rwX "${userDataPath}"`)
+      return
+    }
+  } catch {
+    // ignore
+  }
 
-    if (stats.uid === 0 && currentUid !== 0) {
-      const execPromise = promisify(exec)
-      const username = process.env.USER || process.env.LOGNAME
-      if (username) {
-        await execPromise(`chown -R "${username}:staff" "${userDataPath}"`)
-        await execPromise(`chmod -R u+rwX "${userDataPath}"`)
-      }
+  // Fix root-owned files inside work directory even when top-level dir is user-owned.
+  // mihomo core with setuid root (TUN mode) creates files as root in Providers/,
+  // causing proxy-provider refresh to silently fail due to permission denied.
+  const workDirPath = mihomoWorkDir()
+  if (!existsSync(workDirPath)) return
+
+  try {
+    const { stdout } = await execPromise(
+      `find "${workDirPath}" -user root -print -quit 2>/dev/null`
+    )
+    if (stdout.trim()) {
+      await execPromise(`chown -R "${username}:staff" "${workDirPath}"`)
+      await execPromise(`chmod -R u+rwX "${workDirPath}"`)
     }
   } catch {
     // ignore

--- a/src/main/utils/init.ts
+++ b/src/main/utils/init.ts
@@ -66,17 +66,40 @@ async function fixDataDirPermissions(): Promise<void> {
   const dataDirPath = dataDir()
   if (!existsSync(dataDirPath)) return
 
+  const currentUid = process.getuid?.() || 0
+  if (currentUid === 0) return
+
+  const username = process.env.USER || process.env.LOGNAME
+  if (!username) return
+
+  const execPromise = promisify(exec)
+
   try {
     const stats = await stat(dataDirPath)
-    const currentUid = process.getuid?.() || 0
+    if (stats.uid === 0) {
+      await execPromise(`chown -R "${username}:staff" "${dataDirPath}"`)
+      await execPromise(`chmod -R u+rwX "${dataDirPath}"`)
+      return
+    }
+  } catch {
+    // ignore
+  }
 
-    if (stats.uid === 0 && currentUid !== 0) {
-      const execPromise = promisify(exec)
-      const username = process.env.USER || process.env.LOGNAME
-      if (username) {
-        await execPromise(`chown -R "${username}:staff" "${dataDirPath}"`)
-        await execPromise(`chmod -R u+rwX "${dataDirPath}"`)
-      }
+  // Also fix root-owned files inside work directory.
+  // When mihomo core runs with setuid root (for TUN mode), files it creates
+  // (e.g. proxy-provider caches in Providers/) are owned by root.
+  // The top-level dataDir may be user-owned, but these subdirectory files
+  // will be root-owned, causing silent write failures on provider refresh.
+  const workDirPath = mihomoWorkDir()
+  if (!existsSync(workDirPath)) return
+
+  try {
+    const { stdout } = await execPromise(
+      `find "${workDirPath}" -user root -print -quit 2>/dev/null`
+    )
+    if (stdout.trim()) {
+      await execPromise(`chown -R "${username}:staff" "${workDirPath}"`)
+      await execPromise(`chmod -R u+rwX "${workDirPath}"`)
     }
   } catch {
     // ignore


### PR DESCRIPTION
## Summary

- Fix proxy-provider subscriptions silently failing to refresh on macOS when TUN mode has been used
- Root cause: mihomo core with setuid root creates files as root in `work/*/Providers/`, but permission fix functions only check top-level directory ownership
- Add `find -user root` scan of work directory to detect and fix root-owned files even when top-level dir is user-owned

## Problem

When TUN mode is enabled on macOS, `grantTunPermissions()` sets the mihomo binary to setuid root (`chown root:admin && chmod +sx`). The mihomo core then runs with effective UID 0 and any files it creates (proxy-provider caches in `Providers/`) are owned by root.

Both `fixUserDataPermissions()` (lifecycle.ts) and `fixDataDirPermissions()` (init.ts) only check if the **top-level directory** is root-owned:

```typescript
const stats = await stat(dataDirPath)
if (stats.uid === 0 && currentUid !== 0) { // top-level is user-owned → skips!
```

Since the top-level `dataDir` is user-owned, the check passes and `chown -R` is never executed, leaving root-owned files inside `work/` permanently broken.

## Fix

After checking the top-level directory, also scan the work directory for any root-owned files using `find "${workDirPath}" -user root -print -quit`. If found, apply `chown -R` to fix them.

## Test plan

- [ ] Enable TUN mode on macOS, verify `Providers/` files get created
- [ ] Restart app, verify `fixDataDirPermissions` detects and fixes root-owned files in work dir
- [ ] Verify proxy-provider subscription refreshes successfully after fix
- [ ] Verify no regression on Linux/Windows (early return on non-darwin)

Relates to #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)