### PR TITLE
fix: match desktop file by name for linux app icon lookup

### DIFF
--- a/src/main/utils/icon.ts
+++ b/src/main/utils/icon.ts
@@ -107,7 +107,8 @@ async function findDesktopFile(appPath: string): Promise<string | null> {
               execCmd === appPath ||
               execBasename === execName ||
               execCmd.endsWith(appPath) ||
-              appPath.endsWith(execBasename)
+              appPath.endsWith(execBasename) ||
+              path.basename(file, '.desktop') === execName
             ) {
               return fullPath
             }


### PR DESCRIPTION
#1706 