### PR TITLE
feat: add option to use system DNS when SSID triggers direct modeFeature/ssid disable dns

### DIFF
--- a/src/main/config/controledMihomo.ts
+++ b/src/main/config/controledMihomo.ts
@@ -1,12 +1,13 @@
 import { readFile, writeFile } from 'fs/promises'
 import { existsSync } from 'fs'
+import { ipcMain } from 'electron'
 import { controledMihomoConfigPath } from '../utils/dirs'
 import { parse, stringify } from '../utils/yaml'
 import { generateProfile } from '../core/factory'
 import { defaultControledMihomoConfig } from '../utils/template'
 import { deepMerge } from '../utils/merge'
 import { createLogger } from '../utils/logger'
-import { getAppConfig } from './app'
+import { getAppConfig, patchAppConfig } from './app'
 
 const controledMihomoLogger = createLogger('ControledMihomo')
 
@@ -52,7 +53,23 @@ export async function getControledMihomoConfig(force = false): Promise<Partial<I
 
 export async function patchControledMihomoConfig(patch: Partial<IMihomoConfig>): Promise<void> {
   controledMihomoWriteQueue = controledMihomoWriteQueue.then(async () => {
-    const { controlDns = true, controlSniff = true } = await getAppConfig()
+    const appConfig = await getAppConfig()
+    const { controlDns = true, controlSniff = true, controlDnsBeforePause } = appConfig
+
+    // 当模式从 direct 切换到 rule/global 时，恢复之前保存的 DNS 状态
+    const currentMode = controledMihomoConfig?.mode
+    const newMode = patch.mode
+    if (
+      currentMode === 'direct' &&
+      newMode &&
+      newMode !== 'direct' &&
+      controlDnsBeforePause !== undefined
+    ) {
+      // 恢复 DNS 状态并清除保存的状态
+      await patchAppConfig({ controlDns: controlDnsBeforePause, controlDnsBeforePause: undefined })
+      // 通过事件通知重启核心，避免循环依赖
+      ipcMain.emit('restartCore')
+    }
 
     // 过滤端口字段中的 NaN 值，防止写入无效配置
     const portFields = ['mixed-port', 'socks-port', 'port', 'redir-port', 'tproxy-port'] as const

--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -76,6 +76,10 @@ export async function generateProfile(): Promise<string | undefined> {
   if (!controlDns) {
     delete controledMihomoConfig.dns
     delete controledMihomoConfig.hosts
+    // 同时清空 TUN 的 DNS 劫持，避免 DNS 请求被拦截但无法处理
+    if (controledMihomoConfig.tun) {
+      controledMihomoConfig.tun = { ...controledMihomoConfig.tun, 'dns-hijack': [] }
+    }
   }
   if (!controlSniff) {
     delete controledMihomoConfig.sniffer

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -94,6 +94,13 @@ export function initCoreWatcher(): void {
       safeShowErrorBox('mihomo.error.coreStartFailed', `${e}`)
     }
   })
+
+  // 监听 restartCore 事件（用于 DNS 状态恢复等场景，避免循环依赖）
+  ipcMain.removeAllListeners('restartCore')
+  ipcMain.on('restartCore', async () => {
+    await restartCore()
+    mainWindow?.webContents.send('appConfigUpdated')
+  })
 }
 
 // 清理核心文件监听

--- a/src/main/sys/ssid.ts
+++ b/src/main/sys/ssid.ts
@@ -4,7 +4,7 @@ import { ipcMain, net } from 'electron'
 import { getAppConfig, patchAppConfig, patchControledMihomoConfig } from '../config'
 import { patchMihomoConfig } from '../core/mihomoApi'
 import { mainWindow } from '../window'
-import { getDefaultDevice, restartCore } from '../core/manager'
+import { getDefaultDevice } from '../core/manager'
 
 export async function getCurrentSSID(): Promise<string | undefined> {
   if (process.platform === 'win32') {
@@ -36,32 +36,25 @@ let ssidCheckInterval: NodeJS.Timeout | null = null
 
 export async function checkSSID(): Promise<void> {
   try {
-    const { pauseSSID = [], disableDnsOnPauseSSID = false } = await getAppConfig()
+    const { pauseSSID = [], disableDnsOnPauseSSID = false, controlDns } = await getAppConfig()
     if (pauseSSID.length === 0) return
     const currentSSID = await getCurrentSSID()
     if (currentSSID === lastSSID) return
     lastSSID = currentSSID
     if (currentSSID && pauseSSID.includes(currentSSID)) {
+      if (disableDnsOnPauseSSID) {
+        // 保存当前 DNS 状态到 appConfig，然后关闭 DNS 接管
+        await patchAppConfig({ controlDnsBeforePause: controlDns, controlDns: false })
+      }
       await patchControledMihomoConfig({ mode: 'direct' })
       await patchMihomoConfig({ mode: 'direct' })
-      if (disableDnsOnPauseSSID) {
-        // 关闭 DNS 接管，同时会清空 dns-hijack，需要重启核心
-        await patchAppConfig({ controlDns: false })
-        await patchControledMihomoConfig({})
-        await restartCore()
-      }
       mainWindow?.webContents.send('controledMihomoConfigUpdated')
       mainWindow?.webContents.send('appConfigUpdated')
       ipcMain.emit('updateTrayMenu')
     } else {
+      // DNS 恢复逻辑已移至 patchControledMihomoConfig，会在模式从 direct 切换到 rule/global 时自动触发
       await patchControledMihomoConfig({ mode: 'rule' })
       await patchMihomoConfig({ mode: 'rule' })
-      if (disableDnsOnPauseSSID) {
-        // 恢复 DNS 接管，需要重启核心
-        await patchAppConfig({ controlDns: true })
-        await patchControledMihomoConfig({})
-        await restartCore()
-      }
       mainWindow?.webContents.send('controledMihomoConfigUpdated')
       mainWindow?.webContents.send('appConfigUpdated')
       ipcMain.emit('updateTrayMenu')

--- a/src/main/sys/ssid.ts
+++ b/src/main/sys/ssid.ts
@@ -1,10 +1,10 @@
 import { exec } from 'child_process'
 import { promisify } from 'util'
 import { ipcMain, net } from 'electron'
-import { getAppConfig, patchControledMihomoConfig } from '../config'
+import { getAppConfig, patchAppConfig, patchControledMihomoConfig } from '../config'
 import { patchMihomoConfig } from '../core/mihomoApi'
 import { mainWindow } from '../window'
-import { getDefaultDevice } from '../core/manager'
+import { getDefaultDevice, restartCore } from '../core/manager'
 
 export async function getCurrentSSID(): Promise<string | undefined> {
   if (process.platform === 'win32') {
@@ -36,7 +36,7 @@ let ssidCheckInterval: NodeJS.Timeout | null = null
 
 export async function checkSSID(): Promise<void> {
   try {
-    const { pauseSSID = [] } = await getAppConfig()
+    const { pauseSSID = [], disableDnsOnPauseSSID = false } = await getAppConfig()
     if (pauseSSID.length === 0) return
     const currentSSID = await getCurrentSSID()
     if (currentSSID === lastSSID) return
@@ -44,12 +44,26 @@ export async function checkSSID(): Promise<void> {
     if (currentSSID && pauseSSID.includes(currentSSID)) {
       await patchControledMihomoConfig({ mode: 'direct' })
       await patchMihomoConfig({ mode: 'direct' })
+      if (disableDnsOnPauseSSID) {
+        // 关闭 DNS 接管，同时会清空 dns-hijack，需要重启核心
+        await patchAppConfig({ controlDns: false })
+        await patchControledMihomoConfig({})
+        await restartCore()
+      }
       mainWindow?.webContents.send('controledMihomoConfigUpdated')
+      mainWindow?.webContents.send('appConfigUpdated')
       ipcMain.emit('updateTrayMenu')
     } else {
       await patchControledMihomoConfig({ mode: 'rule' })
       await patchMihomoConfig({ mode: 'rule' })
+      if (disableDnsOnPauseSSID) {
+        // 恢复 DNS 接管，需要重启核心
+        await patchAppConfig({ controlDns: true })
+        await patchControledMihomoConfig({})
+        await restartCore()
+      }
       mainWindow?.webContents.send('controledMihomoConfigUpdated')
+      mainWindow?.webContents.send('appConfigUpdated')
       ipcMain.emit('updateTrayMenu')
     }
   } catch {

--- a/src/renderer/src/components/settings/mihomo-config.tsx
+++ b/src/renderer/src/components/settings/mihomo-config.tsx
@@ -23,6 +23,7 @@ const MihomoConfig: React.FC = () => {
     autoCloseConnection = true,
     testProfileOnStart = true,
     pauseSSID = [],
+    disableDnsOnPauseSSID = false,
     delayTestUrl,
     userAgent,
     subscriptionTimeout = 30000,
@@ -293,6 +294,15 @@ const MihomoConfig: React.FC = () => {
           )
         })}
       </div>
+      <SettingItem title={t('mihomo.disableDnsOnPauseSSID')}>
+        <Switch
+          size="sm"
+          isSelected={disableDnsOnPauseSSID}
+          onValueChange={(v) => {
+            patchAppConfig({ disableDnsOnPauseSSID: v })
+          }}
+        />
+      </SettingItem>
     </SettingCard>
   )
 }

--- a/src/renderer/src/locales/en-US.json
+++ b/src/renderer/src/locales/en-US.json
@@ -167,6 +167,7 @@
   "mihomo.testProfileOnStartTooltip": "Check if the configuration file is valid before starting the core. If invalid, prevent startup and display an error message",
   "mihomo.pauseSSID.title": "Direct Connection for Specific WiFi SSIDs",
   "mihomo.pauseSSID.placeholder": "Enter SSID",
+  "mihomo.disableDnsOnPauseSSID": "Use System DNS on Direct Mode",
   "mihomo.title": "Core Settings",
   "mihomo.restart": "Restart Core",
   "mihomo.memory": "Memory Usage",

--- a/src/renderer/src/locales/fa-IR.json
+++ b/src/renderer/src/locales/fa-IR.json
@@ -147,6 +147,7 @@
   "mihomo.testProfileOnStartTooltip": "قبل از شروع هسته، فایل پیکربندی را بررسی کنید. اگر نامعتبر باشد، شروع مسدود شده و پیام خطا نمایش داده می‌شود",
   "mihomo.pauseSSID.title": "اتصال مستقیم برای SSID‌های خاص",
   "mihomo.pauseSSID.placeholder": "SSID را وارد کنید",
+  "mihomo.disableDnsOnPauseSSID": "استفاده از DNS پیش‌فرض سیستم در حالت اتصال مستقیم",
   "mihomo.coreVersion": "نسخه هسته",
   "mihomo.upgradeCore": "ارتقاء هسته",
   "mihomo.CoreAuthLost": "مجوز هسته از دست رفت",

--- a/src/renderer/src/locales/ru-RU.json
+++ b/src/renderer/src/locales/ru-RU.json
@@ -149,6 +149,7 @@
   "mihomo.testProfileOnStartTooltip": "Проверять конфигурационный файл перед запуском ядра. Если файл недействителен, запуск будет заблокирован с отображением сообщения об ошибке",
   "mihomo.pauseSSID.title": "Прямое подключение для определённых WiFi SSID",
   "mihomo.pauseSSID.placeholder": "Введите SSID",
+  "mihomo.disableDnsOnPauseSSID": "Использовать системный DNS в режиме прямого подключения",
   "mihomo.coreVersion": "Версия ядра",
   "mihomo.upgradeCore": "Обновить ядро",
   "mihomo.coreAuthLost": "Потеряна авторизация ядра",

--- a/src/renderer/src/locales/zh-CN.json
+++ b/src/renderer/src/locales/zh-CN.json
@@ -170,6 +170,7 @@
   "mihomo.testProfileOnStartTooltip": "启动内核前检查配置文件是否有效，若无效则阻止启动并显示错误信息",
   "mihomo.pauseSSID.title": "指定 WiFi SSID 直连",
   "mihomo.pauseSSID.placeholder": "输入 SSID",
+  "mihomo.disableDnsOnPauseSSID": "直连时使用系统默认 DNS",
   "mihomo.coreVersion": "内核版本",
   "mihomo.upgradeCore": "升级内核",
   "mihomo.coreAuthLost": "内核权限丢失",

--- a/src/renderer/src/locales/zh-TW.json
+++ b/src/renderer/src/locales/zh-TW.json
@@ -170,6 +170,7 @@
   "mihomo.testProfileOnStartTooltip": "啟動內核前檢查配置檔案是否有效，若無效則阻止啟動並顯示錯誤訊息",
   "mihomo.pauseSSID.title": "指定 Wi-Fi SSID 直連",
   "mihomo.pauseSSID.placeholder": "輸入 SSID",
+  "mihomo.disableDnsOnPauseSSID": "直連時使用系統預設 DNS",
   "mihomo.coreVersion": "內核版本",
   "mihomo.upgradeCore": "升級內核",
   "mihomo.coreAuthLost": "內核權限丟失",

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -271,6 +271,7 @@ interface IAppConfig {
   logCardStatus?: CardStatus
   hideConnectionCardWave?: boolean
   pauseSSID?: string[]
+  disableDnsOnPauseSSID?: boolean
   mihomoCoreCardStatus?: CardStatus
   overrideCardStatus?: CardStatus
   profileCardStatus?: CardStatus

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -272,6 +272,7 @@ interface IAppConfig {
   hideConnectionCardWave?: boolean
   pauseSSID?: string[]
   disableDnsOnPauseSSID?: boolean
+  controlDnsBeforePause?: boolean
   mihomoCoreCardStatus?: CardStatus
   overrideCardStatus?: CardStatus
   profileCardStatus?: CardStatus


### PR DESCRIPTION
## Summary
Add a new setting to automatically disable Clash Party's DNS when switching to direct mode via SSID detection, allowing the system's default DNS to handle resolution.

## Use Case
When connecting to office/school WiFi that requires internal DNS for intranet access, users want:
1. Auto-switch to direct mode (existing feature)
2. Use system DNS instead of Clash Party's DNS (new feature)

## Changes
- Add `disableDnsOnPauseSSID` setting with UI toggle
- Save DNS state before switching to direct mode, restore when switching back
- Clear `dns-hijack` in TUN config when DNS is disabled
- Use event-driven architecture to avoid circular dependencies
- Add i18n translations for zh-CN, zh-TW, en-US, ru-RU, fa-IR

## Behavior
| Scenario | DNS State |
|----------|-----------|
| Connect to configured SSID → Direct mode | DNS disabled (if option enabled) |
| Leave SSID → Rule mode | DNS restored to previous state |
| Manual switch to Rule/Global | DNS restored to previous state |