### PR TITLE
fix(log): rotate core/sub-store logs by date and avoid O(n²) rewrite at size cap

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -248,8 +248,8 @@ function spawnCoreProcess(config: CoreConfig): ChildProcess {
   }
 
   if (!detached) {
-    const stdout = createCappedLogWritableStream(coreLogPath())
-    const stderr = createCappedLogWritableStream(coreLogPath())
+    const stdout = createCappedLogWritableStream(coreLogPath)
+    const stderr = createCappedLogWritableStream(coreLogPath)
     proc.stdout?.pipe(stdout)
     proc.stderr?.pipe(stderr)
   }

--- a/src/main/resolve/server.ts
+++ b/src/main/resolve/server.ts
@@ -110,8 +110,8 @@ export async function startSubStoreBackendServer(): Promise<void> {
     subStorePort = await findAvailablePort(38324)
     const icon = nativeImage.createFromPath(subStoreIcon)
     icon.toDataURL()
-    const stdout = createCappedLogWritableStream(substoreLogPath())
-    const stderr = createCappedLogWritableStream(substoreLogPath())
+    const stdout = createCappedLogWritableStream(substoreLogPath)
+    const stderr = createCappedLogWritableStream(substoreLogPath)
     const env = {
       SUB_STORE_BACKEND_API_PORT: subStorePort.toString(),
       SUB_STORE_BACKEND_API_HOST: subStoreHost,

--- a/src/main/utils/logFile.ts
+++ b/src/main/utils/logFile.ts
@@ -5,6 +5,15 @@ const MB = 1024 * 1024
 const DEFAULT_MAX_LOG_FILE_SIZE_MB = 10
 const MIN_MAX_LOG_FILE_SIZE_MB = 1
 const TRUNCATE_MARKER = Buffer.from('\n[LOG] File truncated because size limit reached.\n')
+// 触顶压缩后保留的内容比例。压缩后文件回落到约 maxBytes * RATIO 大小，
+// 使后续写入重新走廉价的 appendFile 分支，把压缩频率从「每次写入」降到
+// 「每写满约该比例的上限一次」，整体 I/O 从 O(n²) 降为 O(n)。
+const COMPACTION_RETAIN_RATIO = 0.5
+
+// 日志文件路径既可以是固定字符串，也可以是一个在每次写入时求值的工厂函数。
+// 对于内核 / sub-store 这类长连接日志流，必须传入工厂函数，否则路径会在流创建
+// 时被固化，导致日志永远写入同一个文件、无法按日期轮转。
+type LogFilePath = string | (() => string)
 
 interface LogFileState {
   queue: Promise<void>
@@ -105,7 +114,11 @@ async function appendToFileWithLimitInternal(
     return
   }
 
-  const keepBytes = Math.max(0, maxBytes - data.length - TRUNCATE_MARKER.length)
+  // 触顶后只保留约 maxBytes * COMPACTION_RETAIN_RATIO 的最近内容，使压缩后文件
+  // 远低于上限，接下来的多次写入都能走廉价的 appendFile，避免「文件一旦到达上限后
+  // 每写一行都重读 + 重写整个文件」的 O(n²) I/O 放大。
+  const retainBudget = Math.floor(maxBytes * COMPACTION_RETAIN_RATIO)
+  const keepBytes = Math.max(0, retainBudget - data.length - TRUNCATE_MARKER.length)
   const tail = await readTail(filePath, keepBytes)
   let rewritten = Buffer.concat([tail, TRUNCATE_MARKER, data])
 
@@ -135,12 +148,12 @@ export async function appendToFileWithLimit(
 }
 
 class CappedLogWritable extends Writable {
-  private readonly filePath: string
+  private readonly resolvePath: () => string
   private readonly maxBytes: number
 
-  constructor(filePath: string, maxBytes: number) {
+  constructor(filePath: LogFilePath, maxBytes: number) {
     super()
-    this.filePath = filePath
+    this.resolvePath = typeof filePath === 'function' ? filePath : (): string => filePath
     this.maxBytes = maxBytes
   }
 
@@ -150,7 +163,8 @@ class CappedLogWritable extends Writable {
     callback: (error?: Error | null) => void
   ): void {
     const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding)
-    appendToFileWithLimit(this.filePath, buffer, this.maxBytes).then(
+    // 每次写入时重新解析路径，使日志能按当前日期自动轮转（与 app 日志一致）。
+    appendToFileWithLimit(this.resolvePath(), buffer, this.maxBytes).then(
       () => callback(),
       (error) => callback(error as Error)
     )
@@ -158,7 +172,7 @@ class CappedLogWritable extends Writable {
 }
 
 export function createCappedLogWritableStream(
-  filePath: string,
+  filePath: LogFilePath,
   maxBytes = getGlobalMaxLogFileSizeBytes()
 ): Writable {
   return new CappedLogWritable(filePath, maxBytes)


### PR DESCRIPTION
## 问题

Refs #1912

长时间运行（内核未重启）后，App 出现明显卡顿、代理时断时续。根因是日志子系统的两个缺陷叠加：

### 1. 内核 / sub-store 日志不按日期轮转

App 日志（`clash-party-*.log`）能正常每天轮转，因为 `logger.ts` 每次写入都重新计算路径。但内核 / sub-store 日志走长连接 `Writable` 流，路径在**流创建时只解析一次**：

```ts
// manager.ts / server.ts（修复前）
const stdout = createCappedLogWritableStream(coreLogPath())  // 此刻定死为 core-2026-05-27.log
```

`CappedLogWritable` 把字符串路径固化，导致内核启动后所有日志永远写入同一个文件——例如 `core-2026-05-27.log` 里塞满了 `06-12` 的日志。

### 2. 日志触顶后每写一行都重写整个文件（O(n²)）

`appendToFileWithLimitInternal` 在文件超过 `maxBytes` 后会「读取尾部 + 重写整个文件」，但压缩后 `state.size` 又被填回 ≈ `maxBytes`，导致**下一次写入仍然超顶、再次重写**。即文件一旦达到 10MB 上限，之后每写一行都要读 ~10MB + 重写 ~10MB。

配合 `log-level: info`（内核每条连接输出一行、每秒数百行），这会打满磁盘 I/O，并通过 stdout 管道背压反压到内核进程，使整个 App 卡顿。

两者叠加：因为日志不轮转（缺陷 1），文件永久卡在上限，于是缺陷 2 的昂贵重写路径被**持续触发**。手动清空日志文件可临时缓解，但很快复现。

## 改动

| 文件 | 改动 |
| --- | --- |
| `src/main/utils/logFile.ts` | `createCappedLogWritableStream` 支持传入路径工厂函数 `() => string`，`_write` 时按当前日期重新解析路径（仍兼容字符串路径）；触顶压缩后只保留约一半上限内容 |
| `src/main/core/manager.ts` | 传 `coreLogPath`（函数本身）而非 `coreLogPath()` |
| `src/main/resolve/server.ts` | 传 `substoreLogPath`（函数本身）而非 `substoreLogPath()` |

- **缺陷 1**：流每次写入时重新解析路径，内核 / sub-store 日志即可像 app 日志一样按天自动轮转。
- **缺陷 2**：压缩后只保留约 `maxBytes * 0.5`，使后续写入回到廉价的 `appendFile`，把压缩频率从「每次写入」降到「每写满约半个上限一次」，整体 I/O 由 O(n²) 降为 O(n)。文件大小仍严格 ≤ `maxBytes`。

## 验证

- `pnpm run typecheck:node`：通过
- `eslint` + `prettier --check`（改动文件）：通过
- 行为验证（脚本）：
  - ✅ 路径工厂函数按日期轮转：跨天写入自动切到新文件，旧文件不被污染
  - ✅ 触顶后文件大小始终 ≤ `maxBytes`
  - ✅ 压缩后文件回落（大小在约半个上限到上限之间震荡，而非每次填满 → 证明不再每写必重写）
  - ✅ 字符串路径向后兼容

## 备注（后续可选）

`init.ts` 的 `cleanup()` 按「文件名日期」判断过期且只在启动时执行一次。本 PR 修复缺陷 1 后，文件名日期即与真实日期一致，按文件名清理已变正确；若需进一步增强，可考虑将清理改为定时执行（避免长时间运行的实例日志累积）。该项不在本 PR 范围，留作后续。
