### PR TITLE
fix: prevent main window from showing on auto start when silent start is enabled / 修复开启静默启动后电脑重启自启仍弹出主窗口的问题

### DIFF
--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -90,7 +90,7 @@ export async function createWindow(): Promise<void> {
     }
   })
 
-  if (savedState.isMaximized) {
+  if (savedState.isMaximized && !silentStart) {
     mainWindow.maximize()
   }
 


### PR DESCRIPTION
## Summary
Fixes an issue where the main window unexpectedly pops up during auto-start on Windows if it was previously maximized, overriding the silent start setting.
修复在 Windows 上开启静默启动时，若上次窗口为最大化状态，开机自启仍会弹出主窗口的问题。

## Cause
Calling `maximize()` on Windows automatically makes a hidden window visible, bypassing the silent-start check.
在 Windows 上调用 `maximize()` 会使隐藏窗口强制显示，从而穿透了静默启动的显示拦截。

## Fix
Skip restoring the maximized state during startup if silent start is active.
当开启静默启动时，跳过恢复最大化窗口的操作。

```ts
if (savedState.isMaximized && !silentStart) {
  mainWindow.maximize()
}
```