### PR TITLE
fix: validate TUN exclude CIDR input

### DIFF
--- a/src/renderer/src/locales/en-US.json
+++ b/src/renderer/src/locales/en-US.json
@@ -481,6 +481,7 @@
   "tun.dnsHijack": "DNS Hijack",
   "tun.excludeAddress.title": "Exclude Custom Networks",
   "tun.excludeAddress.placeholder": "Example: 172.20.0.0/16",
+  "tun.excludeAddress.invalid": "Enter a valid CIDR network, for example 172.20.0.0/16",
   "tun.notifications.coreAuthSuccess": "Core Authorization Successful",
   "tun.notifications.firewallResetSuccess": "Firewall Reset Successful",
   "tun.permissions.title": "Administrator Privileges Required",

--- a/src/renderer/src/locales/fa-IR.json
+++ b/src/renderer/src/locales/fa-IR.json
@@ -456,6 +456,7 @@
   "tun.dnsHijack": "ربایش DNS",
   "tun.excludeAddress.title": "مستثنی کردن شبکه‌های سفارشی",
   "tun.excludeAddress.placeholder": "مثال: 172.20.0.0/16",
+  "tun.excludeAddress.invalid": "یک شبکه CIDR معتبر وارد کنید، مانند 172.20.0.0/16",
   "tun.notifications.coreAuthSuccess": "مجوزدهی به هسته با موفقیت انجام شد",
   "tun.notifications.firewallResetSuccess": "بازنشانی دیوار آتش با موفقیت انجام شد",
   "tun.error.tunPermissionDenied": "راه‌اندازی رابط TUN با شکست مواجه شد، لطفا به صورت دستی به هسته مجوز دهید",

--- a/src/renderer/src/locales/ru-RU.json
+++ b/src/renderer/src/locales/ru-RU.json
@@ -460,6 +460,7 @@
   "tun.dnsHijack": "Перехват DNS",
   "tun.excludeAddress.title": "Исключить пользовательские сети",
   "tun.excludeAddress.placeholder": "Пример: 172.20.0.0/16",
+  "tun.excludeAddress.invalid": "Введите корректную CIDR-сеть, например 172.20.0.0/16",
   "tun.notifications.coreAuthSuccess": "Авторизация ядра успешна",
   "tun.notifications.firewallResetSuccess": "Брандмауэр успешно сброшен",
   "tun.error.tunPermissionDenied": "Ошибка запуска TUN, попробуйте вручную предоставить разрешения ядру",

--- a/src/renderer/src/locales/zh-CN.json
+++ b/src/renderer/src/locales/zh-CN.json
@@ -481,6 +481,7 @@
   "tun.dnsHijack": "DNS 劫持",
   "tun.excludeAddress.title": "排除自定义网段",
   "tun.excludeAddress.placeholder": "例：172.20.0.0/16",
+  "tun.excludeAddress.invalid": "请输入有效的 CIDR 网段，例如 172.20.0.0/16",
   "tun.notifications.coreAuthSuccess": "内核授权成功",
   "tun.notifications.firewallResetSuccess": "防火墙重设成功",
   "tun.permissions.title": "需要管理员权限",

--- a/src/renderer/src/locales/zh-TW.json
+++ b/src/renderer/src/locales/zh-TW.json
@@ -481,6 +481,7 @@
   "tun.dnsHijack": "DNS 劫持",
   "tun.excludeAddress.title": "排除自定義網段",
   "tun.excludeAddress.placeholder": "例：172.20.0.0/16",
+  "tun.excludeAddress.invalid": "請輸入有效的 CIDR 網段，例如 172.20.0.0/16",
   "tun.notifications.coreAuthSuccess": "內核授權成功",
   "tun.notifications.firewallResetSuccess": "防火牆重設成功",
   "tun.permissions.title": "需要系統管理員權限",

--- a/src/renderer/src/pages/tun.tsx
+++ b/src/renderer/src/pages/tun.tsx
@@ -11,6 +11,7 @@ import {
   setupFirewall
 } from '@renderer/utils/ipc'
 import { platform } from '@renderer/utils/init'
+import { ipCIDRValidator } from '@renderer/utils/validate'
 import React, { Key, useState } from 'react'
 import { useAppConfig } from '@renderer/hooks/use-app-config'
 import { MdDeleteForever } from 'react-icons/md'
@@ -50,6 +51,20 @@ const Tun: React.FC = () => {
     originSetValues(v)
     setChanged(true)
   }
+  const normalizedRouteExcludeAddress = values.routeExcludeAddress
+    .map((address) => address.trim())
+    .filter(Boolean)
+  const hasInvalidExcludeAddress = normalizedRouteExcludeAddress.some(
+    (address) => !ipCIDRValidator(address)
+  )
+  const excludeAddressInputs = hasInvalidExcludeAddress
+    ? values.routeExcludeAddress
+    : [...values.routeExcludeAddress, '']
+  const getExcludeAddressError = (address: string): string | undefined => {
+    const trimmedAddress = address.trim()
+    if (trimmedAddress === '' || ipCIDRValidator(trimmedAddress)) return undefined
+    return t('tun.excludeAddress.invalid')
+  }
 
   const handleExcludeAddressChange = (value: string, index: number): void => {
     const newExcludeAddresses = [...values.routeExcludeAddress]
@@ -68,11 +83,19 @@ const Tun: React.FC = () => {
   }
 
   const onSave = async (patch: Partial<IMihomoConfig>): Promise<void> => {
+    if (hasInvalidExcludeAddress) return
+
     try {
-      await patchControledMihomoConfig(patch)
+      await patchControledMihomoConfig({
+        ...patch,
+        tun: {
+          ...patch.tun,
+          'route-exclude-address': normalizedRouteExcludeAddress
+        }
+      })
       await mihomoHotReloadConfig()
     } catch (e) {
-      showErrorSync(e, t('common.error.configSaveFailed'))
+      showErrorSync(e, t('common.error.updateCoreConfigFailed'))
     } finally {
       setChanged(false)
     }
@@ -88,6 +111,7 @@ const Tun: React.FC = () => {
               size="sm"
               className="app-nodrag"
               color="primary"
+              isDisabled={hasInvalidExcludeAddress}
               onPress={() =>
                 onSave({
                   tun: {
@@ -251,13 +275,15 @@ const Tun: React.FC = () => {
           </SettingItem>
           <div className="flex flex-col items-stretch">
             <h3 className="mb-2">{t('tun.excludeAddress.title')}</h3>
-            {[...values.routeExcludeAddress, ''].map((address, index) => (
+            {excludeAddressInputs.map((address, index) => (
               <div key={index} className="mb-2 flex">
                 <Input
                   fullWidth
                   size="sm"
                   placeholder={t('tun.excludeAddress.placeholder')}
                   value={address}
+                  isInvalid={Boolean(getExcludeAddressError(address))}
+                  errorMessage={getExcludeAddressError(address)}
                   onValueChange={(v) => handleExcludeAddressChange(v, index)}
                 />
                 {index < values.routeExcludeAddress.length && (


### PR DESCRIPTION
## Summary

  Fixes missing frontend validation for the TUN "Exclude Custom Networks" input.

  Previously, invalid values such as `1`, `abc`, or `192.168.1.0/99` could be saved into `tun.route-exclude-address`, which may cause hot reload or
  later TUN startup failures.
  
<img width="523" height="117" alt="image" src="https://github.com/user-attachments/assets/fcae380d-15ac-42e0-95c5-6f44354338d6" />

<img width="504" height="170" alt="image" src="https://github.com/user-attachments/assets/40e5131c-0232-4bc3-9c5b-6262eb9b246f" />

  ## Changes

  - Reuse the existing `ipCIDRValidator` for TUN exclude-address entries.
  - Show validation errors inline on the invalid input instead of using a global toast.
  - Disable the save button while invalid CIDR entries exist.
  - Trim entries and filter empty values before saving.
  - Add the validation message to all locale files to avoid exposing i18n keys.

  ## Validation

  - `pnpm run typecheck:web`

  ## Notes

  Full pre-commit was not run because the current Windows workspace reports many pre-existing formatting issues during full `format:check`. The files
  changed in this PR were formatted separately.
