### PR TITLE
fix: resolve ip provider dropdown UI delay and fetch race condition

### DIFF
--- a/src/renderer/src/pages/network.tsx
+++ b/src/renderer/src/pages/network.tsx
@@ -1,6 +1,6 @@
 import BasePage from '@renderer/components/base/base-page'
 import NetworkTopologyCard from '@renderer/components/network/network-topology'
-import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Button, Select, SelectItem, Chip, Tooltip, Input } from '@heroui/react'
 import {
   DndContext,
@@ -273,6 +273,7 @@ const IPPage: React.FC = () => {
   const [provider, setProvider] = useState<IPProvider>(
     (appConfig?.networkIPProvider as IPProvider) ?? 'ip.sb'
   )
+  const fetchIdRef = useRef(0)
   const [ipInfo, setIpInfo] = useState<IPInfo | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -458,23 +459,24 @@ const IPPage: React.FC = () => {
   const fetchIP = useCallback(
     async (p?: IPProvider) => {
       const target = p ?? provider
+      const currentFetchId = ++fetchIdRef.current
       setLoading(true)
       setError(null)
       try {
         const data = await fetchIPInfo(IP_ENDPOINTS[target])
+        if (currentFetchId !== fetchIdRef.current) return
         setIpInfo(parseProvider(target, data as Record<string, unknown>))
-        if (p) {
-          setProvider(p)
-          patchAppConfig({ networkIPProvider: p })
-        }
       } catch (e) {
+        if (currentFetchId !== fetchIdRef.current) return
         setError(e instanceof Error ? e.message : t('network.fetchFailed'))
         setIpInfo(null)
       } finally {
-        setLoading(false)
+        if (currentFetchId === fetchIdRef.current) {
+          setLoading(false)
+        }
       }
     },
-    [patchAppConfig, provider, t]
+    [provider, t]
   )
 
   useEffect(() => {
@@ -517,7 +519,11 @@ const IPPage: React.FC = () => {
                         selectedKeys={[provider]}
                         onSelectionChange={(keys) => {
                           const val = Array.from(keys)[0] as IPProvider
-                          if (val) fetchIP(val)
+                          if (val) {
+                            setProvider(val)
+                            patchAppConfig({ networkIPProvider: val })
+                            fetchIP(val)
+                          }
                         }}
                       >
                         {providers.map((p) => (


### PR DESCRIPTION
### 问题描述

在网络信息页面（`network.tsx`）中，IP 提供商的切换交互存在以下两个问题：
1. **状态更新滞后**：目前的逻辑将 `provider` 状态的更新以及用户偏好的持久化（`patchAppConfig`）放在了异步请求 `fetchIPInfo` 完成之后。这导致用户选择下拉框后，必须等请求完下拉框才会变。此外，如果因为网络问题请求失败，不仅 UI 不会更新，用户的切换偏好也丢失了。
2. **异步竞态条件**：当用户连续快速切换提供商时（例如从较慢的 A 切换到较快的 B），较快的 B 会先返回并渲染数据，随后慢请求 A 抛出异常返回，会将原本正确的 UI 状态覆盖为报错信息。

### 修改后的行为

- 用户切换 IP 提供商后，下拉框选项瞬间更新
- 用户选择的提供商偏好会第一时间持久化，不再受当时网络连通性的影响
- 频繁切换提供商时，即使之前的慢请求发生超时或报错，也绝不会覆盖或污染最后一次请求所带来的最新 UI 状态