### PR TITLE
fix: harden main process security boundaries

### DIFF
--- a/scripts/security-helpers.test.ts
+++ b/scripts/security-helpers.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import {
+  assertAllowedCoreName,
+  assertSafeCssFilename,
+  assertSafeFilename,
+  assertSafeId,
+  resolveInside
+} from '../src/main/utils/security'
+
+const root = path.join(process.cwd(), 'tmp-root')
+
+assert.equal(resolveInside(root, 'profiles/a.yaml'), path.join(root, 'profiles', 'a.yaml'))
+assert.throws(() => resolveInside(root, '../outside.yaml'), /escapes/)
+assert.throws(() => resolveInside(root, path.resolve(root, '..', 'outside.yaml')), /escapes/)
+
+assert.doesNotThrow(() => assertSafeId('smart-core-override'))
+assert.throws(() => assertSafeId('../profile'), /Invalid/)
+
+assert.doesNotThrow(() => assertSafeFilename('backup.zip'))
+assert.throws(() => assertSafeFilename('../backup.zip'), /Invalid/)
+assert.throws(() => assertSafeFilename('nested/backup.zip'), /Invalid/)
+
+assert.doesNotThrow(() => assertSafeCssFilename('custom-theme.css'))
+assert.throws(() => assertSafeCssFilename('custom-theme.js'), /extension/)
+
+assert.doesNotThrow(() => assertAllowedCoreName('mihomo-specific'))
+assert.throws(() => assertAllowedCoreName('../evil'), /Invalid/)
+
+process.stdout.write('security helper tests passed\n')

--- a/src/main/config/app.ts
+++ b/src/main/config/app.ts
@@ -5,6 +5,7 @@ import { deepMerge } from '../utils/merge'
 import { defaultConfig } from '../utils/template'
 import { normalizeMaxLogFileSizeMB, setGlobalMaxLogFileSizeMB } from '../utils/logFile'
 import { setAppLogDisabled } from '../utils/logger'
+import { assertAllowedCoreName, assertSafeCssFilename } from '../utils/security'
 
 let appConfig: IAppConfig // config.yaml
 let appConfigWriteQueue: Promise<void> = Promise.resolve()
@@ -34,6 +35,13 @@ export async function getAppConfig(force = false): Promise<IAppConfig> {
 }
 
 export async function patchAppConfig(patch: Partial<IAppConfig>): Promise<void> {
+  if (patch.core !== undefined) {
+    assertAllowedCoreName(patch.core)
+  }
+  if (patch.customTheme !== undefined && patch.customTheme !== '') {
+    assertSafeCssFilename(patch.customTheme)
+  }
+
   appConfigWriteQueue = appConfigWriteQueue.then(async () => {
     const replaceNameserverPolicy = Object.prototype.hasOwnProperty.call(patch, 'nameserverPolicy')
     appConfig = deepMerge(appConfig, patch)

--- a/src/main/config/override.ts
+++ b/src/main/config/override.ts
@@ -4,6 +4,7 @@ import { overrideConfigPath, overridePath } from '../utils/dirs'
 import * as chromeRequest from '../utils/chromeRequest'
 import { parse, stringify } from '../utils/yaml'
 import { DEFAULT_MIHOMO_PORTS } from '../../shared/appConfig'
+import { assertSafeId } from '../utils/security'
 import { getControledMihomoConfig } from './controledMihomo'
 
 let overrideConfig: IOverrideConfig // override.yaml
@@ -28,11 +29,13 @@ export async function setOverrideConfig(config: IOverrideConfig): Promise<void> 
 }
 
 export async function getOverrideItem(id: string | undefined): Promise<IOverrideItem | undefined> {
+  if (id) assertSafeId(id, 'override id')
   const { items } = await getOverrideConfig()
   return items.find((item) => item.id === id)
 }
 
 export async function updateOverrideItem(item: IOverrideItem): Promise<void> {
+  assertSafeId(item.id, 'override id')
   const config = await getOverrideConfig()
   const index = config.items.findIndex((i) => i.id === item.id)
   if (index === -1) {
@@ -43,6 +46,7 @@ export async function updateOverrideItem(item: IOverrideItem): Promise<void> {
 }
 
 export async function addOverrideItem(item: Partial<IOverrideItem>): Promise<void> {
+  if (item.id) assertSafeId(item.id, 'override id')
   const config = await getOverrideConfig()
   const newItem = await createOverride(item)
   if (await getOverrideItem(item.id)) {
@@ -54,6 +58,7 @@ export async function addOverrideItem(item: Partial<IOverrideItem>): Promise<voi
 }
 
 export async function removeOverrideItem(id: string): Promise<void> {
+  assertSafeId(id, 'override id')
   const config = await getOverrideConfig()
   const item = await getOverrideItem(id)
   if (!item) return
@@ -65,6 +70,7 @@ export async function removeOverrideItem(id: string): Promise<void> {
 }
 
 export async function createOverride(item: Partial<IOverrideItem>): Promise<IOverrideItem> {
+  if (item.id) assertSafeId(item.id, 'override id')
   const id = item.id || new Date().getTime().toString(16)
   const newItem = {
     id,
@@ -103,6 +109,7 @@ export async function createOverride(item: Partial<IOverrideItem>): Promise<IOve
 }
 
 export async function getOverride(id: string, ext: 'js' | 'yaml' | 'log'): Promise<string> {
+  assertSafeId(id, 'override id')
   if (!existsSync(overridePath(id, ext))) {
     return ''
   }
@@ -110,5 +117,6 @@ export async function getOverride(id: string, ext: 'js' | 'yaml' | 'log'): Promi
 }
 
 export async function setOverride(id: string, ext: 'js' | 'yaml', content: string): Promise<void> {
+  assertSafeId(id, 'override id')
   await writeFile(overridePath(id, ext), content, 'utf-8')
 }

--- a/src/main/config/profile.ts
+++ b/src/main/config/profile.ts
@@ -1,6 +1,6 @@
 import { access, readFile, rm, unlink, writeFile } from 'fs/promises'
 import { constants, existsSync } from 'fs'
-import { exec, execFile } from 'child_process'
+import { execFile } from 'child_process'
 import { isAbsolute, join, relative, resolve } from 'path'
 import { promisify } from 'util'
 import { randomBytes } from 'crypto'
@@ -25,11 +25,13 @@ import {
   profilePath
 } from '../utils/dirs'
 import { createLogger } from '../utils/logger'
+import { assertSafeId, resolveInside } from '../utils/security'
 import { getAppConfig } from './app'
 import { getControledMihomoConfig } from './controledMihomo'
 
 const profileLogger = createLogger('Profile')
 const execFilePromise = promisify(execFile)
+const RULESET_BEHAVIORS = new Set(['domain', 'ipcidr', 'classical'])
 
 let profileConfig: IProfileConfig
 let profileConfigWriteQueue: Promise<void> = Promise.resolve()
@@ -123,6 +125,7 @@ export async function updateProfileConfig(
 }
 
 export async function getProfileItem(id: string | undefined): Promise<IProfileItem | undefined> {
+  if (id && id !== 'default') assertSafeId(id, 'profile id')
   const { items } = await getProfileConfig()
   if (!id || id === 'default')
     return { id: 'default', type: 'local', name: i18next.t('profiles.emptyProfile') }
@@ -130,6 +133,7 @@ export async function getProfileItem(id: string | undefined): Promise<IProfileIt
 }
 
 export async function changeCurrentProfile(id: string): Promise<void> {
+  assertSafeId(id, 'profile id')
   // 使用队列确保 profile 切换串行执行，避免竞态条件
   let taskError: unknown = null
   changeProfileQueue = changeProfileQueue
@@ -173,6 +177,7 @@ export async function changeCurrentProfile(id: string): Promise<void> {
 }
 
 export async function updateProfileItem(item: IProfileItem): Promise<void> {
+  assertSafeId(item.id, 'profile id')
   await updateProfileConfig((config) => {
     const index = config.items.findIndex((i) => i.id === item.id)
     if (index === -1) {
@@ -184,6 +189,7 @@ export async function updateProfileItem(item: IProfileItem): Promise<void> {
 }
 
 export async function addProfileItem(item: Partial<IProfileItem>): Promise<void> {
+  if (item.id) assertSafeId(item.id, 'profile id')
   const newItem = await createProfile(item)
   let shouldChangeCurrent = false
   let newProfileIsCurrentAfterUpdate = false
@@ -221,6 +227,7 @@ export async function addProfileItem(item: Partial<IProfileItem>): Promise<void>
 }
 
 export async function removeProfileItem(id: string): Promise<void> {
+  assertSafeId(id, 'profile id')
   await removeProfileUpdater(id)
 
   let shouldRestart = false
@@ -409,6 +416,7 @@ async function fetchAndValidateSubscription(options: FetchOptions): Promise<Fetc
 }
 
 export async function createProfile(item: Partial<IProfileItem>): Promise<IProfileItem> {
+  if (item.id) assertSafeId(item.id, 'profile id')
   const id = item.id || new Date().getTime().toString(16)
   const newItem: IProfileItem = {
     id,
@@ -531,6 +539,7 @@ export async function createProfile(item: Partial<IProfileItem>): Promise<IProfi
 }
 
 export async function getProfileStr(id: string | undefined): Promise<string> {
+  if (id && id !== 'default') assertSafeId(id, 'profile id')
   if (existsSync(profilePath(id || 'default'))) {
     return await readFile(profilePath(id || 'default'), 'utf-8')
   } else {
@@ -539,6 +548,7 @@ export async function getProfileStr(id: string | undefined): Promise<string> {
 }
 
 export async function setProfileStr(id: string, content: string): Promise<void> {
+  assertSafeId(id, 'profile id')
   // 读取最新的配置
   const { current } = await getProfileConfig(true)
   await writeFile(profilePath(id), content, 'utf-8')
@@ -617,50 +627,39 @@ function parseSubinfo(str: string): ISubscriptionUserInfo {
   return obj
 }
 
-function isAbsolutePath(path: string): boolean {
-  return path.startsWith('/') || /^[a-zA-Z]:\\/.test(path)
-}
-
-export async function getFileStr(path: string): Promise<string> {
-  const { diffWorkDir = false } = await getAppConfig()
-  const { current } = await getProfileConfig()
-  if (isAbsolutePath(path)) {
-    return await readFile(path, 'utf-8')
-  } else {
-    return await readFile(
-      join(diffWorkDir ? mihomoProfileWorkDir(current) : mihomoWorkDir(), path),
-      'utf-8'
-    )
+function workFilePath(filePath: string, diffWorkDir: boolean, current: string | undefined): string {
+  if (isAbsolute(filePath)) {
+    throw new Error('Absolute paths are not allowed')
   }
+  return resolveInside(diffWorkDir ? mihomoProfileWorkDir(current) : mihomoWorkDir(), filePath)
 }
 
-export async function setFileStr(path: string, content: string): Promise<void> {
+export async function getFileStr(filePath: string): Promise<string> {
   const { diffWorkDir = false } = await getAppConfig()
   const { current } = await getProfileConfig()
-  if (isAbsolutePath(path)) {
-    await writeFile(path, content, 'utf-8')
-  } else {
-    await writeFile(
-      join(diffWorkDir ? mihomoProfileWorkDir(current) : mihomoWorkDir(), path),
-      content,
-      'utf-8'
-    )
+  return await readFile(workFilePath(filePath, diffWorkDir, current), 'utf-8')
+}
+
+export async function setFileStr(filePath: string, content: string): Promise<void> {
+  const { diffWorkDir = false } = await getAppConfig()
+  const { current } = await getProfileConfig()
+  await writeFile(workFilePath(filePath, diffWorkDir, current), content, 'utf-8')
+}
+
+function assertRulesetBehavior(behavior: string): void {
+  if (!RULESET_BEHAVIORS.has(behavior)) {
+    throw new Error(`Invalid ruleset behavior: ${behavior}`)
   }
 }
 
 export async function convertMrsRuleset(filePath: string, behavior: string): Promise<string> {
-  const execAsync = promisify(exec)
+  assertRulesetBehavior(behavior)
 
   const { core = 'mihomo' } = await getAppConfig()
   const corePath = mihomoCorePath(core)
   const { diffWorkDir = false } = await getAppConfig()
   const { current } = await getProfileConfig()
-  let fullPath: string
-  if (isAbsolutePath(filePath)) {
-    fullPath = filePath
-  } else {
-    fullPath = join(diffWorkDir ? mihomoProfileWorkDir(current) : mihomoWorkDir(), filePath)
-  }
+  const fullPath = workFilePath(filePath, diffWorkDir, current)
 
   const tempFileName = `mrs-convert-${randomBytes(8).toString('hex')}.txt`
   const tempFilePath = join(tmpdir(), tempFileName)
@@ -668,7 +667,7 @@ export async function convertMrsRuleset(filePath: string, behavior: string): Pro
   try {
     // 使用 mihomo convert-ruleset 命令转换 MRS 文件为 text 格式
     // 命令格式：mihomo convert-ruleset <behavior> <format> <source>
-    await execAsync(`"${corePath}" convert-ruleset ${behavior} mrs "${fullPath}" "${tempFilePath}"`)
+    await execFilePromise(corePath, ['convert-ruleset', behavior, 'mrs', fullPath, tempFilePath])
     const content = await readFile(tempFilePath, 'utf-8')
     await unlink(tempFilePath)
 

--- a/src/main/core/permissions.ts
+++ b/src/main/core/permissions.ts
@@ -9,13 +9,14 @@ import { mihomoCorePath, mihomoCoreDir } from '../utils/dirs'
 import { managerLogger } from '../utils/logger'
 import { checkAutoRun, enableAutoRun } from '../sys/autoRun'
 import i18next from '../../shared/i18n'
+import { ALLOWED_CORE_NAMES, isAllowedCoreName } from '../utils/security'
 import { checkAdminPrivileges } from './admin'
 
 const execPromise = promisify(exec)
 const execFilePromise = promisify(execFile)
 
 // 内核名称白名单
-const ALLOWED_CORES = ['mihomo', 'mihomo-alpha', 'mihomo-smart'] as const
+const ALLOWED_CORES = ALLOWED_CORE_NAMES
 type AllowedCore = (typeof ALLOWED_CORES)[number]
 type StopCoreBeforeAdminRestart = (force?: boolean) => Promise<void>
 
@@ -26,7 +27,7 @@ export function setStopCoreBeforeAdminRestart(stopCore: StopCoreBeforeAdminResta
 }
 
 export function isValidCoreName(core: string): core is AllowedCore {
-  return ALLOWED_CORES.includes(core as AllowedCore)
+  return isAllowedCoreName(core)
 }
 
 export function validateCorePath(corePath: string): void {

--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -9,16 +9,22 @@ import { triggerSysProxy, disableSysProxySync } from './sys/sysproxy'
 import { exePath } from './utils/dirs'
 
 export function customRelaunch(): void {
-  const script = `while kill -0 ${process.pid} 2>/dev/null; do
+  const script = `pid="$1"
+shift
+while kill -0 "$pid" 2>/dev/null; do
   sleep 0.1
 done
-${process.argv.join(' ')} & disown
+"$@" & disown
 exit
 `
-  spawn('sh', ['-c', script], {
-    detached: true,
-    stdio: 'ignore'
-  })
+  spawn(
+    'sh',
+    ['-c', script, 'relaunch', process.pid.toString(), process.execPath, ...process.argv.slice(1)],
+    {
+      detached: true,
+      stdio: 'ignore'
+    }
+  )
 }
 
 export async function fixUserDataPermissions(): Promise<void> {

--- a/src/main/resolve/autoUpdater.ts
+++ b/src/main/resolve/autoUpdater.ts
@@ -4,48 +4,30 @@ import { existsSync } from 'fs'
 import os from 'os'
 import { exec, execSync, spawn } from 'child_process'
 import { promisify } from 'util'
-import { createHash } from 'crypto'
 import { app, shell } from 'electron'
 import i18next from 'i18next'
 import { mainWindow } from '../window'
 import { appLogger } from '../utils/logger'
 import { dataDir, exeDir, exePath, isPortable, resourcesFilesDir } from '../utils/dirs'
-import { getAppConfig, getControledMihomoConfig } from '../config'
+import { getControledMihomoConfig } from '../config'
 import { DEFAULT_MIHOMO_PORTS } from '../../shared/appConfig'
 import { checkAdminPrivileges } from '../core/manager'
 import { parse } from '../utils/yaml'
 import * as chromeRequest from '../utils/chromeRequest'
-
-const GITHUB_PROXIES = ['https://gh-proxy.org', 'https://ghfast.top', 'https://down.clashparty.org']
-
-function buildDownloadUrls(githubUrl: string, proxyPref = ''): string[] {
-  if (proxyPref === 'direct') return [githubUrl]
-  if (proxyPref && proxyPref !== 'auto') return [`${proxyPref}/${githubUrl}`]
-  // auto: try each proxy then fall back to direct
-  return [...GITHUB_PROXIES.map((p) => `${p}/${githubUrl}`), githubUrl]
-}
+import { downloadVerifiedGitHubAsset } from '../utils/githubAsset'
 
 async function tryDownload(
-  urls: string[],
+  url: string,
   options: Parameters<typeof chromeRequest.get>[1]
 ): Promise<Awaited<ReturnType<typeof chromeRequest.get>>> {
-  let lastError: unknown
-  for (const url of urls) {
-    try {
-      return await chromeRequest.get(url, options)
-    } catch (e) {
-      lastError = e
-    }
-  }
-  throw lastError
+  return await chromeRequest.get(url, options)
 }
 
 export async function checkUpdate(): Promise<IAppVersion | undefined> {
-  const [{ 'mixed-port': mixedPort = DEFAULT_MIHOMO_PORTS.mixed }, { githubProxy = '' }] =
-    await Promise.all([getControledMihomoConfig(), getAppConfig()])
+  const { 'mixed-port': mixedPort = DEFAULT_MIHOMO_PORTS.mixed } = await getControledMihomoConfig()
   const githubUrl =
     'https://github.com/mihomo-party-org/mihomo-party/releases/latest/download/latest.yml'
-  const res = await tryDownload(buildDownloadUrls(githubUrl, githubProxy), {
+  const res = await tryDownload(githubUrl, {
     headers: { 'Content-Type': 'application/octet-stream' },
     proxy: { protocol: 'http', host: '127.0.0.1', port: mixedPort },
     responseType: 'text'
@@ -78,9 +60,7 @@ function compareVersions(a: string, b: string): number {
 }
 
 export async function downloadAndInstallUpdate(version: string): Promise<void> {
-  const [{ 'mixed-port': mixedPort = DEFAULT_MIHOMO_PORTS.mixed }, { githubProxy = '' }] =
-    await Promise.all([getControledMihomoConfig(), getAppConfig()])
-  const githubBase = `https://github.com/mihomo-party-org/mihomo-party/releases/download/v${version}/`
+  const { 'mixed-port': mixedPort = DEFAULT_MIHOMO_PORTS.mixed } = await getControledMihomoConfig()
   const fileMap = {
     'win32-x64': `clash-party-windows-${version}-x64-setup.exe`,
     'win32-ia32': `clash-party-windows-${version}-ia32-setup.exe`,
@@ -109,29 +89,23 @@ export async function downloadAndInstallUpdate(version: string): Promise<void> {
   const proxy = { protocol: 'http' as const, host: '127.0.0.1', port: mixedPort }
   try {
     if (!existsSync(path.join(dataDir(), file))) {
-      const sha256Res = await tryDownload(
-        buildDownloadUrls(`${githubBase}${file}.sha256`, githubProxy),
-        { proxy, responseType: 'text' }
-      )
-      const expectedHash = (sha256Res.data as string).trim().split(/\s+/)[0]
-      const res = await tryDownload(buildDownloadUrls(`${githubBase}${file}`, githubProxy), {
-        responseType: 'arraybuffer',
-        timeout: 0,
-        proxy,
-        headers: { 'Content-Type': 'application/octet-stream' },
-        onProgress: (loaded: number, total: number) => {
-          mainWindow?.webContents.send('updateDownloadProgress', {
-            status: 'downloading',
-            percent: Math.round((loaded / total) * 100)
-          })
+      const fileBuffer = await downloadVerifiedGitHubAsset(
+        'mihomo-party-org',
+        'mihomo-party',
+        `v${version}`,
+        file,
+        {
+          timeout: 0,
+          proxy,
+          onProgress: (loaded: number, total: number) => {
+            mainWindow?.webContents.send('updateDownloadProgress', {
+              status: 'downloading',
+              percent: Math.round((loaded / total) * 100)
+            })
+          }
         }
-      })
+      )
       mainWindow?.webContents.send('updateDownloadProgress', { status: 'verifying' })
-      const fileBuffer = Buffer.from(res.data as ArrayBuffer)
-      const actualHash = createHash('sha256').update(fileBuffer).digest('hex')
-      if (actualHash.toLowerCase() !== expectedHash.toLowerCase()) {
-        throw new Error(`File integrity check failed: expected ${expectedHash}, got ${actualHash}`)
-      }
       await writeFile(path.join(dataDir(), file), fileBuffer)
     }
     if (file.endsWith('.exe')) {

--- a/src/main/resolve/backup.ts
+++ b/src/main/resolve/backup.ts
@@ -1,6 +1,8 @@
 import https from 'https'
 import os from 'os'
 import { existsSync } from 'fs'
+import { mkdir, writeFile } from 'fs/promises'
+import path from 'path'
 import dayjs from 'dayjs'
 import AdmZip from 'adm-zip'
 import { Cron } from 'croner'
@@ -20,6 +22,7 @@ import {
   themesDir
 } from '../utils/dirs'
 import { getAppConfig } from '../config'
+import { assertSafeFilename, resolveInside } from '../utils/security'
 
 let backupCronJob: Cron | null = null
 
@@ -109,6 +112,42 @@ function createBackupZip(): AdmZip {
   return zip
 }
 
+const ALLOWED_BACKUP_FILES = new Set([
+  'config.yaml',
+  'mihomo.yaml',
+  'profile.yaml',
+  'override.yaml'
+])
+
+const ALLOWED_BACKUP_DIRS = ['themes', 'profiles', 'override', 'rules', 'substore']
+
+function isAllowedBackupEntry(entryName: string): boolean {
+  const normalized = entryName.replace(/\\/g, '/').replace(/^\/+/, '')
+  if (!normalized || normalized.includes('\0')) return false
+  if (normalized.split('/').some((part) => part === '..')) return false
+  if (ALLOWED_BACKUP_FILES.has(normalized)) return true
+  return ALLOWED_BACKUP_DIRS.some((dir) => normalized === dir || normalized.startsWith(`${dir}/`))
+}
+
+async function extractBackupZip(zip: AdmZip): Promise<void> {
+  for (const entry of zip.getEntries()) {
+    const entryName = entry.entryName.replace(/\\/g, '/').replace(/^\/+/, '')
+    if (!isAllowedBackupEntry(entryName)) {
+      await systemLogger.warn(`Skipped unsafe backup entry: ${entry.entryName}`)
+      continue
+    }
+
+    const targetPath = resolveInside(dataDir(), entryName)
+    if (entry.isDirectory) {
+      await mkdir(targetPath, { recursive: true })
+      continue
+    }
+
+    await mkdir(path.dirname(targetPath), { recursive: true })
+    await writeFile(targetPath, entry.getData())
+  }
+}
+
 export async function webdavBackup(): Promise<boolean> {
   const { client, webdavDir, webdavMaxBackups } = await getWebDAVClient()
   const zip = createBackupZip()
@@ -159,10 +198,12 @@ export async function webdavBackup(): Promise<boolean> {
 }
 
 export async function webdavRestore(filename: string): Promise<void> {
+  assertSafeFilename(filename, 'backup filename')
+  if (!filename.endsWith('.zip')) throw new Error('Invalid backup filename')
   const { client, webdavDir } = await getWebDAVClient()
   const zipData = await client.getFileContents(`${webdavDir}/${filename}`)
   const zip = new AdmZip(zipData as Buffer)
-  zip.extractAllTo(dataDir(), true)
+  await extractBackupZip(zip)
 }
 
 export async function listWebdavBackups(): Promise<string[]> {
@@ -172,6 +213,8 @@ export async function listWebdavBackups(): Promise<string[]> {
 }
 
 export async function webdavDelete(filename: string): Promise<void> {
+  assertSafeFilename(filename, 'backup filename')
+  if (!filename.endsWith('.zip')) throw new Error('Invalid backup filename')
   const { client, webdavDir } = await getWebDAVClient()
   await client.deleteFile(`${webdavDir}/${filename}`)
 }
@@ -273,7 +316,7 @@ export async function importLocalBackup(): Promise<boolean> {
   if (!result.canceled && result.filePaths.length > 0) {
     const filePath = result.filePaths[0]
     const zip = new AdmZip(filePath)
-    zip.extractAllTo(dataDir(), true)
+    await extractBackupZip(zip)
     await systemLogger.info(`Local backup imported from: ${filePath}`)
     return true
   }

--- a/src/main/resolve/server.ts
+++ b/src/main/resolve/server.ts
@@ -7,13 +7,13 @@ import path from 'path'
 import { nativeImage } from 'electron'
 import express from 'express'
 import AdmZip from 'adm-zip'
-import * as chromeRequest from '../utils/chromeRequest'
 import subStoreIcon from '../../../resources/subStoreIcon.png?asset'
 import { dataDir, mihomoWorkDir, subStoreDir, substoreLogPath } from '../utils/dirs'
 import { getAppConfig, getControledMihomoConfig } from '../config'
 import { systemLogger } from '../utils/logger'
 import { createCappedLogWritableStream } from '../utils/logFile'
 import { DEFAULT_MIHOMO_PORTS, DEFAULT_USE_SUB_STORE } from '../../shared/appConfig'
+import { downloadVerifiedGitHubAsset } from '../utils/githubAsset'
 
 export let pacPort: number
 export let subStorePort: number
@@ -161,34 +161,29 @@ export async function downloadSubStore(): Promise<void> {
 
     // 下载后端文件
     const tempBackendPath = path.join(tempDir, 'sub-store.bundle.cjs')
-    const backendRes = await chromeRequest.get(
-      'https://github.com/sub-store-org/Sub-Store/releases/latest/download/sub-store.bundle.js',
-      {
-        responseType: 'arraybuffer',
-        headers: { 'Content-Type': 'application/octet-stream' },
-        proxy: {
-          protocol: 'http',
-          host: '127.0.0.1',
-          port: mixedPort
-        }
-      }
+    const proxy = {
+      protocol: 'http' as const,
+      host: '127.0.0.1',
+      port: mixedPort
+    }
+    const backendData = await downloadVerifiedGitHubAsset(
+      'sub-store-org',
+      'Sub-Store',
+      'latest',
+      'sub-store.bundle.js',
+      { proxy }
     )
-    await writeFile(tempBackendPath, Buffer.from(backendRes.data as Buffer))
+    await writeFile(tempBackendPath, backendData)
     // 下载前端文件
-    const frontendRes = await chromeRequest.get(
-      'https://github.com/sub-store-org/Sub-Store-Front-End/releases/latest/download/dist.zip',
-      {
-        responseType: 'arraybuffer',
-        headers: { 'Content-Type': 'application/octet-stream' },
-        proxy: {
-          protocol: 'http',
-          host: '127.0.0.1',
-          port: mixedPort
-        }
-      }
+    const frontendData = await downloadVerifiedGitHubAsset(
+      'sub-store-org',
+      'Sub-Store-Front-End',
+      'latest',
+      'dist.zip',
+      { proxy }
     )
     // 先解压到临时目录
-    const zip = new AdmZip(Buffer.from(frontendRes.data as Buffer))
+    const zip = new AdmZip(frontendData)
     zip.extractAllTo(tempDir, true)
     await cp(tempBackendPath, backendPath)
     if (existsSync(frontendDir)) {

--- a/src/main/resolve/theme.ts
+++ b/src/main/resolve/theme.ts
@@ -8,6 +8,7 @@ import * as chromeRequest from '../utils/chromeRequest'
 import { getControledMihomoConfig } from '../config'
 import { DEFAULT_MIHOMO_PORTS } from '../../shared/appConfig'
 import { mainWindow } from '../window'
+import { assertSafeCssFilename } from '../utils/security'
 import { floatingWindow } from './floatingWindow'
 
 let insertedCSSKeyMain: string | undefined = undefined
@@ -61,15 +62,18 @@ export async function importThemes(files: string[]): Promise<void> {
 }
 
 export async function readTheme(theme: string): Promise<string> {
+  assertSafeCssFilename(theme)
   if (!existsSync(path.join(themesDir(), theme))) return ''
   return await readFile(path.join(themesDir(), theme), 'utf-8')
 }
 
 export async function writeTheme(theme: string, css: string): Promise<void> {
+  assertSafeCssFilename(theme)
   await writeFile(path.join(themesDir(), theme), css)
 }
 
 export async function applyTheme(theme: string): Promise<void> {
+  assertSafeCssFilename(theme)
   const css = await readTheme(theme)
   await mainWindow?.webContents.removeInsertedCSS(insertedCSSKeyMain || '')
   insertedCSSKeyMain = await mainWindow?.webContents.insertCSS(css)

--- a/src/main/sys/misc.ts
+++ b/src/main/sys/misc.ts
@@ -13,24 +13,42 @@ import {
   resourcesDir
 } from '../utils/dirs'
 import { checkAdminPrivileges } from '../core/admin'
+import { assertSafeFilename } from '../utils/security'
+
+const selectedFilePaths = new Set<string>()
+
+function rememberSelectedFiles(files: string[] | undefined): string[] | undefined {
+  files?.forEach((file) => selectedFilePaths.add(path.resolve(file)))
+  return files
+}
+
+function assertSelectedFile(filePath: string): void {
+  if (!selectedFilePaths.has(path.resolve(filePath))) {
+    throw new Error('File was not selected by the user')
+  }
+}
 
 export function getFilePath(
   ext: string[],
   title?: string,
   filterName?: string
 ): string[] | undefined {
-  return dialog.showOpenDialogSync({
-    title: title || i18next.t('common.dialog.selectSubscriptionFile'),
-    filters: [{ name: filterName || `${ext} file`, extensions: ext }],
-    properties: ['openFile']
-  })
+  return rememberSelectedFiles(
+    dialog.showOpenDialogSync({
+      title: title || i18next.t('common.dialog.selectSubscriptionFile'),
+      filters: [{ name: filterName || `${ext} file`, extensions: ext }],
+      properties: ['openFile']
+    })
+  )
 }
 
 export async function readTextFile(filePath: string): Promise<string> {
+  assertSelectedFile(filePath)
   return await readFile(filePath, 'utf8')
 }
 
 export async function readImageFileDataURL(filePath: string): Promise<string> {
+  assertSelectedFile(filePath)
   const ext = path.extname(filePath).toLowerCase()
   const mimeType =
     ext === '.jpg' || ext === '.jpeg'
@@ -46,6 +64,7 @@ export async function readImageFileDataURL(filePath: string): Promise<string> {
 }
 
 export function openFile(type: 'profile' | 'override', id: string, ext?: 'yaml' | 'js'): void {
+  assertSafeFilename(id, 'file id')
   if (type === 'profile') {
     shell.openPath(profilePath(id))
   }
@@ -110,18 +129,32 @@ export function resetAppConfig(): void {
       }
     ).unref()
   } else {
-    const script = `while kill -0 ${process.pid} 2>/dev/null; do
+    const script = `pid="$1"
+data_dir="$2"
+shift 2
+while kill -0 "$pid" 2>/dev/null; do
   sleep 0.1
 done
-  rm -rf '${dataDir()}'
-  ${process.argv.join(' ')} & disown
+  rm -rf -- "$data_dir"
+  "$@" & disown
 exit
 `
-    spawn('sh', ['-c', `"${script}"`], {
-      shell: true,
-      detached: true,
-      stdio: 'ignore'
-    })
+    spawn(
+      'sh',
+      [
+        '-c',
+        script,
+        'reset-app',
+        process.pid.toString(),
+        dataDir(),
+        process.execPath,
+        ...process.argv.slice(1)
+      ],
+      {
+        detached: true,
+        stdio: 'ignore'
+      }
+    )
   }
   app.quit()
 }

--- a/src/main/utils/dirs.ts
+++ b/src/main/utils/dirs.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync } from 'fs'
 import path from 'path'
 import { is } from '@electron-toolkit/utils'
 import { app } from 'electron'
+import { assertAllowedCoreName } from './security'
 
 export const homeDir = app.getPath('home')
 
@@ -77,7 +78,11 @@ export function mihomoCoreDir(): string {
 }
 
 export function mihomoCorePath(core: string): string {
+  assertAllowedCoreName(core)
   const isWin = process.platform === 'win32'
+  if (core === 'mihomo-specific') {
+    return path.join(mihomoCoreDir(), `mihomo-specific${isWin ? '.exe' : ''}`)
+  }
   // 处理 Smart 内核
   if (core === 'mihomo-smart') {
     return path.join(mihomoCoreDir(), `mihomo-smart${isWin ? '.exe' : ''}`)

--- a/src/main/utils/github.ts
+++ b/src/main/utils/github.ts
@@ -6,20 +6,12 @@ import { join } from 'path'
 import { createGunzip } from 'zlib'
 import AdmZip from 'adm-zip'
 import { stopCore } from '../core/manager'
-import { getAppConfig } from '../config'
 import { mihomoCoreDir } from './dirs'
 import * as chromeRequest from './chromeRequest'
 import { createLogger } from './logger'
+import { downloadVerifiedGitHubAsset } from './githubAsset'
 
 const log = createLogger('GitHub')
-
-const GITHUB_PROXIES = ['https://gh-proxy.org', 'https://ghfast.top', 'https://down.clashparty.org']
-
-function buildDownloadUrls(githubUrl: string, proxyPref = ''): string[] {
-  if (proxyPref === 'direct') return [githubUrl]
-  if (proxyPref && proxyPref !== 'auto') return [`${proxyPref}/${githubUrl}`]
-  return [...GITHUB_PROXIES.map((p) => `${p}/${githubUrl}`), githubUrl]
-}
 
 export interface GitHubTag {
   name: string
@@ -123,29 +115,18 @@ export function clearVersionCache(owner: string, repo: string): void {
  * @param url 下载 URL
  * @param outputPath 输出路径
  */
-async function downloadGitHubAsset(url: string, outputPath: string): Promise<void> {
-  const { githubProxy = '' } = await getAppConfig()
-  const urls = buildDownloadUrls(url, githubProxy)
-  let lastError: unknown
-  for (const candidate of urls) {
-    try {
-      log.debug(`Downloading asset from ${candidate}`)
-      const response = await chromeRequest.get(candidate, {
-        responseType: 'arraybuffer',
-        timeout: 30000
-      })
-      await writeFile(outputPath, Buffer.from(response.data as Buffer))
-      log.debug(`Successfully downloaded asset to ${outputPath}`)
-      return
-    } catch (error) {
-      log.warn(`Download failed from ${candidate}, trying next`, error)
-      lastError = error
-    }
-  }
-  log.error(`Failed to download asset from all sources`, lastError)
-  throw lastError instanceof Error
-    ? new Error(`Download error: ${lastError.message}`)
-    : new Error('Failed to download core file')
+async function downloadGitHubAsset(
+  owner: string,
+  repo: string,
+  tag: string,
+  assetName: string,
+  outputPath: string
+): Promise<void> {
+  const data = await downloadVerifiedGitHubAsset(owner, repo, tag, assetName, {
+    timeout: 30000
+  })
+  await writeFile(outputPath, data)
+  log.debug(`Successfully downloaded verified asset to ${outputPath}`)
 }
 
 /**
@@ -169,7 +150,7 @@ export async function installMihomoCore(version: string): Promise<void> {
 
     const isWin = plat === 'win32'
     const urlExt = isWin ? 'zip' : 'gz'
-    const downloadURL = `https://github.com/MetaCubeX/mihomo/releases/download/${version}/${name}-${version}.${urlExt}`
+    const assetName = `${name}-${version}.${urlExt}`
 
     const coreDir = mihomoCoreDir()
     const tempZip = join(coreDir, `temp-core.${urlExt}`)
@@ -185,7 +166,7 @@ export async function installMihomoCore(version: string): Promise<void> {
     }
 
     // 下载文件
-    await downloadGitHubAsset(downloadURL, tempZip)
+    await downloadGitHubAsset('MetaCubeX', 'mihomo', version, assetName, tempZip)
 
     // 解压文件
     if (urlExt === 'zip') {

--- a/src/main/utils/githubAsset.ts
+++ b/src/main/utils/githubAsset.ts
@@ -1,0 +1,72 @@
+import { createHash } from 'crypto'
+import * as chromeRequest from './chromeRequest'
+
+interface GitHubReleaseAsset {
+  name: string
+  browser_download_url: string
+  digest?: string
+}
+
+interface GitHubRelease {
+  assets: GitHubReleaseAsset[]
+}
+
+interface DownloadOptions {
+  proxy?: NonNullable<Parameters<typeof chromeRequest.get>[1]>['proxy']
+  timeout?: number
+  onProgress?: (loaded: number, total: number) => void
+}
+
+async function getRelease(owner: string, repo: string, tag: string): Promise<GitHubRelease> {
+  const releasePath = tag === 'latest' ? 'latest' : `tags/${encodeURIComponent(tag)}`
+  const response = await chromeRequest.get<GitHubRelease>(
+    `https://api.github.com/repos/${owner}/${repo}/releases/${releasePath}`,
+    {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28'
+      },
+      responseType: 'json',
+      timeout: 10000
+    }
+  )
+  return response.data
+}
+
+function parseSha256Digest(asset: GitHubReleaseAsset): string {
+  const digest = asset.digest || ''
+  const match = digest.match(/^sha256:([a-fA-F0-9]{64})$/)
+  if (!match) {
+    throw new Error(`GitHub release asset ${asset.name} does not include a SHA-256 digest`)
+  }
+  return match[1].toLowerCase()
+}
+
+export async function downloadVerifiedGitHubAsset(
+  owner: string,
+  repo: string,
+  tag: string,
+  assetName: string,
+  options: DownloadOptions = {}
+): Promise<Buffer> {
+  const release = await getRelease(owner, repo, tag)
+  const asset = release.assets.find((item) => item.name === assetName)
+  if (!asset) {
+    throw new Error(`GitHub release asset not found: ${owner}/${repo} ${tag} ${assetName}`)
+  }
+
+  const expectedHash = parseSha256Digest(asset)
+  const response = await chromeRequest.get(asset.browser_download_url, {
+    responseType: 'arraybuffer',
+    timeout: options.timeout ?? 30000,
+    proxy: options.proxy,
+    headers: { 'Content-Type': 'application/octet-stream' },
+    onProgress: options.onProgress
+  })
+  const data = Buffer.from(response.data as Buffer)
+  const actualHash = createHash('sha256').update(data).digest('hex')
+  if (actualHash !== expectedHash) {
+    throw new Error(`Asset integrity check failed: expected ${expectedHash}, got ${actualHash}`)
+  }
+  return data
+}

--- a/src/main/utils/ipc.ts
+++ b/src/main/utils/ipc.ts
@@ -129,6 +129,7 @@ import { getIconDataURL } from './icon'
 import { getAppName } from './appName'
 import { logDir, rulePath } from './dirs'
 import { installMihomoCore, getGitHubTags, clearVersionCache } from './github'
+import { assertSafeId } from './security'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AsyncFn = (...args: any[]) => Promise<any>
@@ -176,10 +177,12 @@ async function clearMihomoVersionCache(): Promise<void> {
 }
 
 async function getRuleStr(id: string): Promise<string> {
+  assertSafeId(id, 'rule id')
   return await readFile(rulePath(id), 'utf-8')
 }
 
 async function setRuleStr(id: string, str: string): Promise<void> {
+  assertSafeId(id, 'rule id')
   await writeFile(rulePath(id), str, 'utf-8')
 }
 

--- a/src/main/utils/security.ts
+++ b/src/main/utils/security.ts
@@ -1,0 +1,57 @@
+import path from 'path'
+
+export const ALLOWED_CORE_NAMES = [
+  'mihomo',
+  'mihomo-alpha',
+  'mihomo-smart',
+  'mihomo-specific'
+] as const
+
+export type AllowedCoreName = (typeof ALLOWED_CORE_NAMES)[number]
+
+export function isAllowedCoreName(core: string): core is AllowedCoreName {
+  return ALLOWED_CORE_NAMES.includes(core as AllowedCoreName)
+}
+
+export function assertAllowedCoreName(core: string): asserts core is AllowedCoreName {
+  if (!isAllowedCoreName(core)) {
+    throw new Error(`Invalid core name: ${core}`)
+  }
+}
+
+export function assertSafeId(id: string, label = 'id'): void {
+  if (!/^[A-Za-z0-9_-]+$/.test(id)) {
+    throw new Error(`Invalid ${label}`)
+  }
+}
+
+export function assertSafeFilename(name: string, label = 'filename'): void {
+  if (
+    !name ||
+    path.isAbsolute(name) ||
+    path.basename(name) !== name ||
+    name === '.' ||
+    name === '..'
+  ) {
+    throw new Error(`Invalid ${label}`)
+  }
+}
+
+export function assertSafeCssFilename(name: string): void {
+  assertSafeFilename(name, 'theme')
+  if (!name.endsWith('.css')) {
+    throw new Error('Invalid theme extension')
+  }
+}
+
+export function resolveInside(root: string, target: string): string {
+  const resolvedRoot = path.resolve(root)
+  const resolvedTarget = path.resolve(resolvedRoot, target)
+  const relativePath = path.relative(resolvedRoot, resolvedTarget)
+
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`Path escapes allowed directory: ${target}`)
+  }
+
+  return resolvedTarget
+}

--- a/src/renderer/src/pages/override.tsx
+++ b/src/renderer/src/pages/override.tsx
@@ -106,7 +106,7 @@ const Override: React.FC = () => {
       if (event.dataTransfer?.files) {
         const file = event.dataTransfer.files[0]
         if (file.name.endsWith('.js') || file.name.endsWith('.yaml')) {
-          const content = await readTextFile((file as File & { path: string }).path)
+          const content = await file.text()
           try {
             await addOverrideItemRef.current({
               name: file.name,

--- a/src/renderer/src/pages/profiles.tsx
+++ b/src/renderer/src/pages/profiles.tsx
@@ -208,8 +208,7 @@ const Profiles: React.FC = () => {
         const file = event.dataTransfer.files[0]
         if (file.name.endsWith('.yml') || file.name.endsWith('.yaml')) {
           try {
-            const path = window.api.webUtils.getPathForFile(file)
-            const content = await readTextFile(path)
+            const content = await file.text()
             await addProfileItemRef.current({ name: file.name, type: 'local', file: content })
           } catch (e) {
             toast.error(String(e))

--- a/src/renderer/src/pages/proxies.tsx
+++ b/src/renderer/src/pages/proxies.tsx
@@ -325,7 +325,7 @@ const Proxies: React.FC = () => {
           >
             <CardBody className="w-full h-14">
               <div className="flex justify-between h-full gap-3">
-                <div className="flex min-w-0 h-full text-ellipsis overflow-hidden whitespace-nowrap">
+                <div className="flex min-w-0 flex-1 items-center overflow-hidden whitespace-nowrap">
                   {groups[index].icon ? (
                     <Avatar
                       className="bg-transparent mr-2 shrink-0"
@@ -338,21 +338,26 @@ const Proxies: React.FC = () => {
                       }
                     />
                   ) : null}
-                  <div className="flex min-w-0 flex-col h-full">
-                    <div className="text-ellipsis overflow-hidden whitespace-nowrap leading-tight text-md flex-5 flex items-center">
-                      <span title={groups[index].name} className="flag-emoji inline-block truncate">
-                        {groups[index].name}
+                  <div className="flex min-w-0 items-center overflow-hidden whitespace-nowrap">
+                    <span title={groups[index].name} className="flag-emoji text-md truncate">
+                      {groups[index].name}
+                    </span>
+                    {proxyDisplayMode === 'full' && (
+                      <span
+                        title={groups[index].type}
+                        className="ml-2 shrink-0 text-sm text-foreground-500"
+                      >
+                        {groups[index].type}
                       </span>
-                    </div>
-                    <div className="text-ellipsis overflow-hidden whitespace-nowrap text-[10px] text-foreground-500 leading-tight flex-3 flex items-center">
-                      <span>{groups[index].type}</span>
+                    )}
+                    {groups[index].now && (
                       <span
                         title={groups[index].now}
-                        className="flag-emoji ml-1 inline-block truncate"
+                        className="flag-emoji ml-2 min-w-0 truncate text-sm text-foreground-500"
                       >
                         {groups[index].now}
                       </span>
-                    </div>
+                    )}
                   </div>
                 </div>
                 <div className="flex items-center">


### PR DESCRIPTION
## Summary
- validate main-process IPC path, ID, theme, WebDAV, and core-name inputs
- replace ruleset conversion shell execution with argument-vector execFile
- verify GitHub release assets by release digest before installing executable/script updates
- constrain backup restore to known backup entries and avoid restoring executable runtime bundles
- add focused security helper regression tests

## Validation
- pnpm exec tsx scripts/security-helpers.test.ts
- pnpm run review

## Security scan
- Follow-up Codex Security scan will be run after PR creation in this thread.