### PR TITLE
fix: decouple startup detection from stdout log-level, allow all vali…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,129 @@
+# Clash Party (mihomo-party) 工作规范
+
+## 项目概述
+
+基于 Electron + React + TypeScript 的跨平台代理客户端。
+
+## 技术栈
+
+- **框架**: Electron + electron-vite
+- **前端**: React 19 + TypeScript + TailwindCSS v4
+- **UI 组件库**: @heroui/react
+- **动画**: framer-motion
+- **路由**: react-router-dom v7
+- **构建**: electron-vite + electron-builder
+- **包管理**: pnpm
+
+## 目录结构
+
+```
+src/
+├── main/        # Electron 主进程
+├── preload/     # 预加载脚本
+├── renderer/    # React 前端
+│   ├── src/
+│   │   ├── App.tsx
+│   │   ├── assets/
+│   │   ├── components/
+│   │   ├── hooks/
+│   │   ├── pages/
+│   │   ├── routes/
+│   │   └── utils/
+│   ├── index.html
+│   └── floating.html
+└── shared/      # 主进程和渲染进程共享代码
+```
+
+## 代码规范
+
+### 格式化 (Prettier)
+
+- 单引号 (`singleQuote: true`)
+- 无分号 (`semi: false`)
+- 行宽 100 (`printWidth: 100`)
+- 无尾逗号 (`trailingComma: none`)
+- 缩进 2 空格
+- 文件末尾保留空行
+
+### 命名规范
+
+- **文件/目录**: kebab-case (如 `app-config.ts`, `use-theme.ts`)
+- **React 组件**: PascalCase (如 `ProxyCard.tsx`)
+- **函数/变量**: camelCase
+- **常量**: UPPER_SNAKE_CASE
+- **类型/接口**: PascalCase，接口名加 `I` 前缀（如 `IProxyConfig`）
+- **枚举**: PascalCase
+
+### TypeScript 规范
+
+- 优先使用 `interface` 而非 `type` 定义对象类型
+- 禁止使用 `any`，优先 `unknown` 或明确的类型
+- 禁止非空断言 (`!`)
+- 未使用的变量/参数用 `_` 前缀
+- 模块解析使用 `bundler`
+
+### React 规范
+
+- 使用函数组件 + Hooks
+- 优先使用 React Router v7 的路由方案
+- 使用 TailwindCSS 类名进行样式编写，避免内联 style
+- 国际化使用 `react-i18next` + `i18next`
+- 状态管理优先使用 SWR (`swr`) 管理服务端状态
+
+### 导入顺序
+
+1. 内置模块
+2. 外部依赖
+3. 内部模块
+4. 父级模块
+5. 同级模块
+6. 索引文件
+
+### 路径别名
+
+- `@renderer/*` -> `src/renderer/src/*`
+
+## 脚本命令
+
+```bash
+pnpm run dev              # 启动开发环境
+pnpm run lint             # ESLint 检查并修复
+pnpm run lint:check       # ESLint 检查（只报告）
+pnpm run format           # Prettier 格式化
+pnpm run format:check     # Prettier 检查
+pnpm run typecheck        # TypeScript 类型检查
+pnpm run review           # 完整检查（format:check + lint:check + typecheck）
+pnpm run build:linux      # 构建 Linux 版本
+pnpm run build:mac        # 构建 macOS 版本
+pnpm run build:win        # 构建 Windows 版本
+```
+
+## 工作流程
+
+### 代码修改流程（必须先提案后执行）
+
+1. 当需要修改代码时，必须先**分析问题，给出完整的解决方案**
+2. 在方案中明确列出：
+   - 要修改哪些文件
+   - 修改内容摘要
+   - 潜在风险或影响范围
+3. **等待我确认后**，才能执行代码修改
+4. 修改完成后，运行 `pnpm run lint && pnpm run typecheck` 确保无错误
+
+### Git 提交流程
+
+1. 所有 Git 操作（add、commit、push 等）**必须先询问我**
+2. 未经我明确同意，不得执行任何 Git 提交或推送
+3. 提交前必须运行 `pnpm run review` 确保全部检查通过
+
+### 通用规则
+
+1. **不要** 修改 `dist/`, `out/`, `extra/` 目录下的文件
+2. **不要** 提交配置文件中的密钥和令牌
+3. 新功能或修复需要保持向后兼容
+
+## 环境要求
+
+- Node.js >= 20
+- pnpm >= 10
+- 不要锁定包版本到低版本

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["AGENTS.md"],
+  "permission": {
+    "edit": "ask",
+    "bash": {
+      "git push": "ask",
+      "git commit": "ask",
+      "git *": "ask",
+      "*": "allow"
+    }
+  }
+}

--- a/src/main/config/controledMihomo.ts
+++ b/src/main/config/controledMihomo.ts
@@ -52,7 +52,10 @@ export async function getControledMihomoConfig(force = false): Promise<Partial<I
   return controledMihomoConfig
 }
 
-export async function patchControledMihomoConfig(patch: Partial<IMihomoConfig>): Promise<void> {
+export async function patchControledMihomoConfig(
+  patch: Partial<IMihomoConfig>,
+  skipHotPatch = false
+): Promise<void> {
   controledMihomoWriteQueue = controledMihomoWriteQueue.then(async () => {
     const appConfig = await getAppConfig()
     const {
@@ -111,21 +114,23 @@ export async function patchControledMihomoConfig(patch: Partial<IMihomoConfig>):
     await writeFile(controledMihomoConfigPath(), stringify(controledMihomoConfig), 'utf-8')
 
     // 优先对运行中内核进行热更新，避免无意义重启
-    try {
-      await patchMihomoConfig(patch)
-    } catch (error) {
-      controledMihomoLogger.warn(
-        'Hot patch /configs failed, changes will apply on next restart',
-        error
-      )
-    }
-
-    // log-level 改变时重连日志 WebSocket，使新等级立刻生效
-    if (patch['log-level']) {
+    if (!skipHotPatch) {
       try {
-        await startMihomoLogs()
+        await patchMihomoConfig(patch)
       } catch (error) {
-        controledMihomoLogger.warn('Failed to restart log stream after log-level change', error)
+        controledMihomoLogger.warn(
+          'Hot patch /configs failed, changes will apply on next restart',
+          error
+        )
+      }
+
+      // log-level 改变时重连日志 WebSocket，使新等级立刻生效
+      if (patch['log-level']) {
+        try {
+          await startMihomoLogs()
+        } catch (error) {
+          controledMihomoLogger.warn('Failed to restart log stream after log-level change', error)
+        }
       }
     }
   })

--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -161,9 +161,7 @@ export async function generateProfile(): Promise<string | undefined> {
       addedProxyServerRouteExcludes
     )
   }
-  // 确保可以拿到基础日志信息
-  // 使用 debug 可以调试内核相关问题 `debug/pprof`
-  if (['info', 'debug'].includes(profile['log-level']) === false) {
+  if (!['info', 'debug', 'warning', 'error', 'silent'].includes(profile['log-level'])) {
     profile['log-level'] = 'info'
   }
   // 删除空的局域网允许列表，避免局域网访问异常

--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -132,6 +132,10 @@ export async function generateProfile(): Promise<string | undefined> {
   )
   let controledMihomoConfig = await getControledMihomoConfig()
 
+  factoryLogger.info(
+    `[TUN-DEBUG] generateProfile: controled config tun=${JSON.stringify(controledMihomoConfig.tun)}, log-level=${controledMihomoConfig['log-level']}`
+  )
+
   // 根据开关状态过滤控制配置
   controledMihomoConfig = { ...controledMihomoConfig }
   if (!controlDns) {
@@ -164,6 +168,9 @@ export async function generateProfile(): Promise<string | undefined> {
   if (!['info', 'debug', 'warning', 'error', 'silent'].includes(profile['log-level'])) {
     profile['log-level'] = 'info'
   }
+  factoryLogger.info(
+    `[TUN-DEBUG] generateProfile: final profile log-level=${profile['log-level']}, tun.enable=${profile.tun?.enable}`
+  )
   // 删除空的局域网允许列表，避免局域网访问异常
   if (!profile['lan-allowed-ips']?.length) {
     delete profile['lan-allowed-ips']

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -288,6 +288,8 @@ function setupCoreListeners(
   resolve: (value: Promise<void>[]) => void,
   reject: (reason: unknown) => void
 ): void {
+  let startupResolved = false
+
   proc.on('close', async (code, signal) => {
     managerLogger.info(`Core closed, code: ${code}, signal: ${signal}`)
 
@@ -312,77 +314,69 @@ function setupCoreListeners(
   proc.stdout?.on('data', async (data) => {
     const str = data.toString()
 
-    // TUN 权限错误
+    // TUN 权限错误（error 级别，不受 log-level 过滤）
     if (str.includes('configure tun interface: operation not permitted')) {
-      patchControledMihomoConfig({ tun: { enable: false } })
-      mainWindow?.webContents.send('controledMihomoConfigUpdated')
-      ipcMain.emit('updateTrayMenu')
-      reject(i18next.t('tun.error.tunPermissionDenied'))
+      if (!startupResolved) {
+        patchControledMihomoConfig({ tun: { enable: false } })
+        mainWindow?.webContents.send('controledMihomoConfigUpdated')
+        ipcMain.emit('updateTrayMenu')
+        reject(i18next.t('tun.error.tunPermissionDenied'))
+      }
       return
     }
 
-    // 控制器监听错误
+    // 控制器监听错误（error 级别，不受 log-level 过滤）
     const isControllerError =
       (process.platform !== 'win32' && str.includes('External controller unix listen error')) ||
       (process.platform === 'win32' && str.includes('External controller pipe listen error'))
 
     if (isControllerError) {
-      managerLogger.error('External controller listen error detected:', str)
+      if (!startupResolved) {
+        managerLogger.error('External controller listen error detected:', str)
 
-      if (process.platform === 'win32') {
-        managerLogger.info('Attempting Windows pipe cleanup and retry...')
-        try {
-          await cleanupWindowsNamedPipes(true)
-          await new Promise((r) => setTimeout(r, 2000))
-        } catch (cleanupError) {
-          managerLogger.error('Pipe cleanup failed:', cleanupError)
+        if (process.platform === 'win32') {
+          managerLogger.info('Attempting Windows pipe cleanup and retry...')
+          try {
+            await cleanupWindowsNamedPipes(true)
+            await new Promise((r) => setTimeout(r, 2000))
+          } catch (cleanupError) {
+            managerLogger.error('Pipe cleanup failed:', cleanupError)
+          }
         }
-      }
 
-      reject(i18next.t('mihomo.error.externalControllerListenError'))
+        reject(i18next.t('mihomo.error.externalControllerListenError'))
+      }
       return
     }
-
-    // API 就绪
-    const isApiReady =
-      (process.platform !== 'win32' && str.includes('RESTful API unix listening at')) ||
-      (process.platform === 'win32' && str.includes('RESTful API pipe listening at'))
-
-    if (isApiReady) {
-      resolve([
-        new Promise((innerResolve) => {
-          proc.stdout?.on('data', async (innerData) => {
-            if (
-              innerData
-                .toString()
-                .toLowerCase()
-                .includes('start initial compatible provider default')
-            ) {
-              try {
-                mainWindow?.webContents.send('groupsUpdated')
-                mainWindow?.webContents.send('rulesUpdated')
-                await uploadRuntimeConfig()
-              } catch {
-                // ignore
-              }
-              await patchMihomoConfig({ 'log-level': logLevel })
-              innerResolve()
-            }
-          })
-        })
-      ])
-
-      await waitForCoreReady()
-      await getAxios(true)
-      await Promise.all([
-        startMihomoTraffic(),
-        startMihomoConnections(),
-        startMihomoLogs(),
-        startMihomoMemory()
-      ])
-      retry = 10
-    }
   })
+
+  // 通过 HTTP API 轮询检测内核就绪，替代 stdout 日志检测
+  // 这样 log-level 设为 warning/error/silent 也不会影响启动检测
+  ;(async () => {
+    await waitForCoreReady()
+    if (startupResolved) return
+    startupResolved = true
+
+    resolve([])
+
+    try {
+      mainWindow?.webContents.send('groupsUpdated')
+      mainWindow?.webContents.send('rulesUpdated')
+      await uploadRuntimeConfig()
+    } catch {
+      // ignore
+    }
+    await patchMihomoConfig({ 'log-level': logLevel }).catch(() => {})
+
+    await getAxios(true)
+    await Promise.all([
+      startMihomoTraffic(),
+      startMihomoConnections(),
+      startMihomoLogs(),
+      startMihomoMemory()
+    ])
+    retry = 10
+  })()
 }
 
 // 启动核心

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -40,7 +40,6 @@ import {
   stopMihomoTraffic,
   stopMihomoLogs,
   stopMihomoMemory,
-  patchMihomoConfig,
   getAxios
 } from './mihomoApi'
 import { generateProfile } from './factory'
@@ -197,6 +196,10 @@ function buildCoreEnv(safePath?: string, ageSecretKey?: string): NodeJS.ProcessE
 async function prepareCore(detached: boolean, skipStop = false): Promise<CoreConfig> {
   await ensureRuntimeFiles()
 
+  managerLogger.info(
+    `[TUN-DEBUG] prepareCore: detached=${detached}, skipStop=${skipStop}, isRestarting=${isRestarting}`
+  )
+
   const [appConfig, mihomoConfig] = await Promise.all([getAppConfig(), getControledMihomoConfig()])
 
   const {
@@ -207,6 +210,9 @@ async function prepareCore(detached: boolean, skipStop = false): Promise<CoreCon
   } = appConfig
 
   const { 'log-level': logLevel = 'info' as LogLevel, tun } = mihomoConfig
+  managerLogger.info(
+    `[TUN-DEBUG] prepareCore: tun=${JSON.stringify(tun)}, logLevel=${logLevel}, autoSetDNS=${autoSetDNS}`
+  )
 
   // 清理轻量模式遗留的后台核心
   await stopPidFileCore()
@@ -258,11 +264,17 @@ async function prepareCore(detached: boolean, skipStop = false): Promise<CoreCon
 function spawnCoreProcess(config: CoreConfig): ChildProcess {
   const { corePath, workDir, safePath, ipcPath, cpuPriority, ageSecretKey, detached } = config
 
+  managerLogger.info(
+    `[TUN-DEBUG] spawnCoreProcess: corePath=${corePath}, workDir=${workDir}, tunEnabled=${config.tunEnabled}, detached=${detached}`
+  )
+
   const proc = spawn(corePath, ['-d', workDir, ctlParam, ipcPath], {
     detached,
     stdio: detached ? 'ignore' : undefined,
     env: buildCoreEnv(safePath, ageSecretKey)
   })
+
+  managerLogger.info(`[TUN-DEBUG] spawnCoreProcess: PID=${proc.pid}, isRestarting=${isRestarting}`)
 
   if (process.platform === 'win32' && proc.pid) {
     os.setPriority(
@@ -290,8 +302,14 @@ function setupCoreListeners(
 ): void {
   let startupResolved = false
 
+  managerLogger.info(
+    `[TUN-DEBUG] setupCoreListeners entered, PID=${proc.pid}, logLevel=${logLevel}, isRestarting=${isRestarting}`
+  )
+
   proc.on('close', async (code, signal) => {
-    managerLogger.info(`Core closed, code: ${code}, signal: ${signal}`)
+    managerLogger.info(
+      `[TUN-DEBUG] Core closed event: PID=${proc.pid}, code=${code}, signal=${signal}, child===proc=${child === proc}, isRestarting=${isRestarting}`
+    )
 
     if (child === proc) {
       child = null
@@ -316,11 +334,19 @@ function setupCoreListeners(
 
     // TUN 权限错误（error 级别，不受 log-level 过滤）
     if (str.includes('configure tun interface: operation not permitted')) {
+      managerLogger.info(
+        `[TUN-DEBUG] TUN permission error detected, startupResolved=${startupResolved}, PID=${proc.pid}`
+      )
       if (!startupResolved) {
+        managerLogger.info('[TUN-DEBUG] TUN error BEFORE startupResolved - rejecting startup')
         patchControledMihomoConfig({ tun: { enable: false } })
         mainWindow?.webContents.send('controledMihomoConfigUpdated')
         ipcMain.emit('updateTrayMenu')
+        const { updateTrayIcon: updateTrayIconAfterTunError } = await import('../resolve/tray')
+        await updateTrayIconAfterTunError()
         reject(i18next.t('tun.error.tunPermissionDenied'))
+      } else {
+        managerLogger.info('[TUN-DEBUG] TUN error AFTER startupResolved - silently ignored')
       }
       return
     }
@@ -331,6 +357,9 @@ function setupCoreListeners(
       (process.platform === 'win32' && str.includes('External controller pipe listen error'))
 
     if (isControllerError) {
+      managerLogger.info(
+        `[TUN-DEBUG] Controller listen error detected, startupResolved=${startupResolved}, PID=${proc.pid}`
+      )
       if (!startupResolved) {
         managerLogger.error('External controller listen error detected:', str)
 
@@ -353,21 +382,32 @@ function setupCoreListeners(
   // 通过 HTTP API 轮询检测内核就绪，替代 stdout 日志检测
   // 这样 log-level 设为 warning/error/silent 也不会影响启动检测
   ;(async () => {
+    managerLogger.info(`[TUN-DEBUG] HTTP polling IIFE started, PID=${proc.pid}`)
+
     await waitForCoreReady()
-    if (startupResolved) return
+
+    managerLogger.info(
+      `[TUN-DEBUG] waitForCoreReady completed, startupResolved=${startupResolved}, PID=${proc.pid}`
+    )
+
+    if (startupResolved) {
+      managerLogger.info('[TUN-DEBUG] startupResolved already true, skipping resolve')
+      return
+    }
     startupResolved = true
+    managerLogger.info('[TUN-DEBUG] startupResolved set to true, calling resolve')
 
     resolve([Promise.resolve()])
+    managerLogger.info('[TUN-DEBUG] resolve called, executing post-startup tasks')
 
     try {
       mainWindow?.webContents.send('groupsUpdated')
       mainWindow?.webContents.send('rulesUpdated')
       await uploadRuntimeConfig()
     } catch {
-      // ignore
+      managerLogger.info('[TUN-DEBUG] uploadRuntimeConfig failed (may be due to restart)')
     }
-    await patchMihomoConfig({ 'log-level': logLevel }).catch(() => {})
-
+    managerLogger.info('[TUN-DEBUG] Starting monitors...')
     await getAxios(true)
     await Promise.all([
       startMihomoTraffic(),
@@ -376,11 +416,16 @@ function setupCoreListeners(
       startMihomoMemory()
     ])
     retry = 10
+    managerLogger.info('[TUN-DEBUG] Post-startup tasks complete')
   })()
 }
 
 // 启动核心
 export async function startCore(detached = false, skipStop = false): Promise<Promise<void>[]> {
+  managerLogger.info(
+    `[TUN-DEBUG] startCore called: detached=${detached}, skipStop=${skipStop}, child=${child?.pid ?? 'null'}, isRestarting=${isRestarting}`
+  )
+
   const config = await prepareCore(detached, skipStop)
   const proc = spawnCoreProcess(config)
   child = proc
@@ -400,6 +445,10 @@ export async function startCore(detached = false, skipStop = false): Promise<Pro
 
 // 停止核心
 export async function stopCore(force = false): Promise<void> {
+  managerLogger.info(
+    `[TUN-DEBUG] stopCore called: force=${force}, child=${child?.pid ?? 'null'}, isRestarting=${isRestarting}`
+  )
+
   if (!force && process.platform === 'darwin') {
     try {
       await recoverDNS()
@@ -409,9 +458,12 @@ export async function stopCore(force = false): Promise<void> {
   }
 
   if (child) {
+    const pid = child.pid
+    managerLogger.info(`[TUN-DEBUG] stopCore: killing child PID=${pid}`)
     child.removeAllListeners()
     child.kill('SIGINT')
     child = null
+    managerLogger.info(`[TUN-DEBUG] stopCore: child killed (PID=${pid}) and set to null`)
   }
 
   stopMihomoTraffic()
@@ -433,6 +485,8 @@ setStopCoreBeforeAdminRestart(stopCore)
 
 // 重启核心
 export async function restartCore(): Promise<void> {
+  managerLogger.info(`[TUN-DEBUG] restartCore called: isRestarting=${isRestarting}`)
+
   if (isRestarting) {
     managerLogger.info('Core restart already in progress, skipping duplicate request')
     return
@@ -444,17 +498,23 @@ export async function restartCore(): Promise<void> {
 
   try {
     // 先显式停止核心，确保状态干净
+    managerLogger.info('[TUN-DEBUG] restartCore: stopping core...')
     await stopCore()
 
     // 尝试启动核心，失败时重试
     while (retryCount < maxRetries) {
       try {
         // skipStop=true 因为我们已经在上面停止了核心
+        managerLogger.info(`[TUN-DEBUG] restartCore: starting core (attempt ${retryCount + 1})...`)
         await startCore(false, true)
+        managerLogger.info('[TUN-DEBUG] restartCore: core started successfully')
         return // 成功启动，退出函数
       } catch (e) {
         retryCount++
-        managerLogger.error(`restart core failed (attempt ${retryCount}/${maxRetries})`, e)
+        managerLogger.error(
+          `[TUN-DEBUG] restart core failed (attempt ${retryCount}/${maxRetries})`,
+          e
+        )
 
         if (retryCount >= maxRetries) {
           throw e
@@ -468,6 +528,7 @@ export async function restartCore(): Promise<void> {
       }
     }
   } finally {
+    managerLogger.info('[TUN-DEBUG] restartCore: finally block, setting isRestarting=false')
     isRestarting = false
   }
 }
@@ -549,5 +610,9 @@ async function checkProfile(
 
 // 权限检查入口（从 permissions.ts 调用）
 export async function checkAdminRestartForTun(): Promise<void> {
+  managerLogger.info(
+    `[TUN-DEBUG] checkAdminRestartForTun (manager wrapper) called, argv includes --admin-restart-for-tun: ${process.argv.includes('--admin-restart-for-tun')}`
+  )
   await checkAdminRestartForTunWithRestart(restartCore)
+  managerLogger.info('[TUN-DEBUG] checkAdminRestartForTun (manager wrapper) completed')
 }

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -357,7 +357,7 @@ function setupCoreListeners(
     if (startupResolved) return
     startupResolved = true
 
-    resolve([])
+    resolve([Promise.resolve()])
 
     try {
       mainWindow?.webContents.send('groupsUpdated')

--- a/src/main/core/permissions.ts
+++ b/src/main/core/permissions.ts
@@ -350,11 +350,17 @@ export async function validateTunPermissionsOnStartup(
 ): Promise<void> {
   const { tun } = await getControledMihomoConfig()
 
+  managerLogger.info(`[TUN-DEBUG] validateTunPermissionsOnStartup: tun=${JSON.stringify(tun)}`)
+
   if (!tun?.enable) {
+    managerLogger.info('[TUN-DEBUG] validateTunPermissionsOnStartup: TUN not enabled, skipping')
     return
   }
 
   const hasPermissions = await checkMihomoCorePermissions()
+  managerLogger.info(
+    `[TUN-DEBUG] validateTunPermissionsOnStartup: hasPermissions=${hasPermissions}`
+  )
 
   if (!hasPermissions) {
     // 启动时没有权限，静默禁用 TUN，不弹窗打扰用户
@@ -373,21 +379,38 @@ export async function validateTunPermissionsOnStartup(
   }
 }
 
+let adminRestartForTunCompleted = false
+
 export async function checkAdminRestartForTun(restartCore: () => Promise<void>): Promise<void> {
-  if (process.argv.includes('--admin-restart-for-tun')) {
+  if (adminRestartForTunCompleted) {
+    managerLogger.info('[TUN-DEBUG] checkAdminRestartForTun: already completed, skipping')
+    return
+  }
+
+  const hasArg = process.argv.includes('--admin-restart-for-tun')
+  managerLogger.info(
+    `[TUN-DEBUG] checkAdminRestartForTun entered: hasArg=${hasArg}, platform=${process.platform}`
+  )
+
+  if (hasArg) {
     managerLogger.info('Detected admin restart for TUN mode, auto-enabling TUN...')
 
     try {
       if (process.platform === 'win32') {
+        managerLogger.info('[TUN-DEBUG] Windows platform, checking admin privileges...')
         const hasAdminPrivileges = await checkAdminPrivileges()
+        managerLogger.info(`[TUN-DEBUG] Admin privileges: ${hasAdminPrivileges}`)
         if (hasAdminPrivileges) {
-          await patchControledMihomoConfig({ tun: { enable: true }, dns: { enable: true } })
+          managerLogger.info('[TUN-DEBUG] Patching config: tun.enable=true, dns.enable=true')
+          await patchControledMihomoConfig({ tun: { enable: true }, dns: { enable: true } }, true)
+          managerLogger.info('[TUN-DEBUG] Config patched, checking auto-run status...')
 
           const autoRunEnabled = await checkAutoRun()
           if (autoRunEnabled) {
             await enableAutoRun()
           }
 
+          managerLogger.info('[TUN-DEBUG] Calling restartCore()...')
           await restartCore()
 
           managerLogger.info('TUN mode auto-enabled after admin restart')
@@ -395,16 +418,29 @@ export async function checkAdminRestartForTun(restartCore: () => Promise<void>):
           const { mainWindow } = await import('../index')
           mainWindow?.webContents.send('controledMihomoConfigUpdated')
           ipcMain.emit('updateTrayMenu')
+          const { updateTrayIcon } = await import('../resolve/tray')
+          await updateTrayIcon()
+          managerLogger.info('[TUN-DEBUG] Admin restart TUN flow completed successfully')
         } else {
           managerLogger.warn('Admin restart detected but no admin privileges found')
         }
+      } else {
+        managerLogger.info(
+          '[TUN-DEBUG] Non-Windows platform with --admin-restart-for-tun flag - nothing to do'
+        )
       }
     } catch (error) {
       managerLogger.error('Failed to auto-enable TUN after admin restart', error)
     }
   } else {
+    managerLogger.info(
+      '[TUN-DEBUG] No --admin-restart-for-tun, calling validateTunPermissionsOnStartup'
+    )
     await validateTunPermissionsOnStartup(restartCore)
+    managerLogger.info('[TUN-DEBUG] validateTunPermissionsOnStartup completed')
   }
+
+  adminRestartForTunCompleted = true
 }
 
 export function checkTunPermissions(): Promise<boolean> {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -98,7 +98,13 @@ const App: React.FC = () => {
     const currentSiderCard = getSiderCardByPath(location.pathname)
     if (!currentSiderCard || currentSiderCard === lastSelectedSiderCard) return
     patchAppConfig({ lastSelectedSiderCard: currentSiderCard })
-  }, [hasAppConfig, rememberSelectedSiderCard, lastSelectedSiderCard, location.pathname, patchAppConfig])
+  }, [
+    hasAppConfig,
+    rememberSelectedSiderCard,
+    lastSelectedSiderCard,
+    location.pathname,
+    patchAppConfig
+  ])
 
   useEffect(() => {
     siderWidthValueRef.current = siderWidthValue

--- a/src/renderer/src/components/sider/tun-switcher.tsx
+++ b/src/renderer/src/components/sider/tun-switcher.tsx
@@ -3,7 +3,7 @@ import { useControledMihomoConfig } from '@renderer/hooks/use-controled-mihomo-c
 import BorderSwitch from '@renderer/components/base/border-swtich'
 import { TbDeviceIpadHorizontalBolt } from 'react-icons/tb'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { updateTrayIconImmediate } from '@renderer/utils/ipc'
+import { updateTrayIcon, updateTrayIconImmediate } from '@renderer/utils/ipc'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import React from 'react'
@@ -101,6 +101,7 @@ const TunSwitcher: React.FC<Props> = (props) => {
     }
     window.electron.ipcRenderer.send('updateFloatingWindow')
     window.electron.ipcRenderer.send('updateTrayMenu')
+    await updateTrayIcon()
   }
 
   if (iconOnly) {


### PR DESCRIPTION
…d log levels

Replace stdout-based API readiness detection (which relied on info-level log messages filtered by log-level) with HTTP API polling via waitForCoreReady(). This fixes:

1. factory.ts: allow all valid log-level values (info/debug/warning/error/silent) to pass through, only override invalid values

2. manager.ts: remove isApiReady stdout check — use HTTP polling instead, so startup detection works at any log-level (including silent)

3. manager.ts: remove inner stdout listener (provider-ready detection) — execute provider side effects directly after HTTP polling succeeds

4. manager.ts: add startupResolved flag to prevent race between HTTP polling and stdout error detection (TUN, controller error)