### PR TITLE
fix: custom tray icon not dimming on macOS when app loses focus

### DIFF
--- a/src/main/resolve/tray.ts
+++ b/src/main/resolve/tray.ts
@@ -597,9 +597,18 @@ function createMultiScaleTrayImage(icon: Electron.NativeImage): Electron.NativeI
     })
   }
 
-  if (!trayImage.isEmpty()) return trayImage
+  if (!trayImage.isEmpty()) {
+    if (process.platform === 'darwin') {
+      trayImage.setTemplateImage(true)
+    }
+    return trayImage
+  }
 
-  return resizeTrayImageForScale(icon, 1)
+  const fallback = resizeTrayImageForScale(icon, 1)
+  if (process.platform === 'darwin') {
+    fallback.setTemplateImage(true)
+  }
+  return fallback
 }
 
 function createCustomTrayImage(customTrayIcon: string): TrayImage | null {


### PR DESCRIPTION
## Problem

When using a custom tray icon on macOS (`customTrayIcon` config), the icon stays at full brightness even after the app loses focus. Other system menu bar icons dim automatically when inactive.

## Root Cause

macOS requires `setTemplateImage(true)` on tray `NativeImage` to auto-dim when inactive. The initial tray creation correctly sets it, but `createMultiScaleTrayImage` — used for custom tray icons — never calls it.

## Fix

Add `setTemplateImage(true)` for macOS in `createMultiScaleTrayImage` before returning.