### PR TITLE
Limit renderer memory retention

### DIFF
--- a/src/renderer/src/components/network/network-topology.tsx
+++ b/src/renderer/src/components/network/network-topology.tsx
@@ -267,7 +267,7 @@ const NetworkTopologyCard: React.FC = () => {
     }
     window.electron.ipcRenderer.on('mihomoConnections', handler)
     return () => {
-      window.electron.ipcRenderer.removeAllListeners('mihomoConnections')
+      window.electron.ipcRenderer.removeListener('mihomoConnections', handler)
     }
   }, [isPaused])
 

--- a/src/renderer/src/pages/connections.tsx
+++ b/src/renderer/src/pages/connections.tsx
@@ -44,7 +44,25 @@ import { useControledMihomoConfig } from '@renderer/hooks/use-controled-mihomo-c
 
 let cachedConnections: IMihomoConnectionDetail[] = []
 const MAX_QUEUE_SIZE = 100
+const MAX_MEMORY_CACHE_SIZE = 200
 const CONNECTIONS_FILTER_KEY = 'connections-filter'
+
+function rememberMemoryCacheKey(order: string[], key: string): string[] {
+  const existingIndex = order.indexOf(key)
+  if (existingIndex !== -1) {
+    order.splice(existingIndex, 1)
+  }
+  order.push(key)
+
+  const evicted: string[] = []
+  while (order.length > MAX_MEMORY_CACHE_SIZE) {
+    const oldest = order.shift()
+    if (oldest) {
+      evicted.push(oldest)
+    }
+  }
+  return evicted
+}
 
 const Connections: React.FC = () => {
   const { t } = useTranslation()
@@ -84,11 +102,13 @@ const Connections: React.FC = () => {
 
   const iconRequestQueue = useRef(new Set<string>())
   const processingIcons = useRef(new Set<string>())
+  const iconMemoryOrder = useRef<string[]>([])
   const processIconTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const processIconIdleCallback = useRef<number | null>(null)
 
   const appNameRequestQueue = useRef(new Set<string>())
   const processingAppNames = useRef(new Set<string>())
+  const appNameMemoryOrder = useRef<string[]>([])
   const processAppNameTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => {
     activeConnectionsRef.current = activeConnections
@@ -229,7 +249,14 @@ const Connections: React.FC = () => {
       try {
         const appName = await getAppName(path)
         if (appName) {
-          setAppNameCache((prev) => ({ ...prev, [path]: appName }))
+          setAppNameCache((prev) => {
+            const next = { ...prev, [path]: appName }
+            const evicted = rememberMemoryCacheKey(appNameMemoryOrder.current, path)
+            evicted.forEach((key) => {
+              delete next[key]
+            })
+            return next
+          })
         }
       } catch {
         // ignore
@@ -270,7 +297,14 @@ const Connections: React.FC = () => {
 
         saveIconToCache(path, processedDataURL)
 
-        setIconMap((prev) => ({ ...prev, [path]: processedDataURL }))
+        setIconMap((prev) => {
+          const next = { ...prev, [path]: processedDataURL }
+          const evicted = rememberMemoryCacheKey(iconMemoryOrder.current, path)
+          evicted.forEach((key) => {
+            delete next[key]
+          })
+          return next
+        })
 
         const firstConnection = filteredConnectionsRef.current[0]
         if (firstConnection?.metadata.processPath === path) {
@@ -298,6 +332,7 @@ const Connections: React.FC = () => {
 
   useEffect(() => {
     if (!displayIcon || findProcessMode === 'off') return
+    let loadOtherPathsTimer: ReturnType<typeof setTimeout> | null = null
 
     const visiblePaths = new Set<string>()
     const otherPaths = new Set<string>()
@@ -327,7 +362,14 @@ const Connections: React.FC = () => {
 
       const fromCache = getIconFromCache(path)
       if (fromCache) {
-        setIconMap((prev) => ({ ...prev, [path]: fromCache }))
+        setIconMap((prev) => {
+          const next = { ...prev, [path]: fromCache }
+          const evicted = rememberMemoryCacheKey(iconMemoryOrder.current, path)
+          evicted.forEach((key) => {
+            delete next[key]
+          })
+          return next
+        })
         if (isVisible && filteredConnections[0]?.metadata.processPath === path) {
           setFirstItemRefreshTrigger((prev) => prev + 1)
         }
@@ -356,7 +398,7 @@ const Connections: React.FC = () => {
         })
       }
 
-      setTimeout(loadOtherPaths, 100)
+      loadOtherPathsTimer = setTimeout(loadOtherPaths, 100)
     }
 
     if (processIconTimer.current) clearTimeout(processIconTimer.current)
@@ -369,6 +411,7 @@ const Connections: React.FC = () => {
     }
 
     return (): void => {
+      if (loadOtherPathsTimer) clearTimeout(loadOtherPathsTimer)
       if (processIconTimer.current) clearTimeout(processIconTimer.current)
       if (processIconIdleCallback.current) cancelIdleCallback(processIconIdleCallback.current)
       if (processAppNameTimer.current) clearTimeout(processAppNameTimer.current)

--- a/src/renderer/src/pages/logs.tsx
+++ b/src/renderer/src/pages/logs.tsx
@@ -25,9 +25,8 @@ const cachedLogs: {
   }
 }
 
-window.electron.ipcRenderer.on('mihomoLogs', (_e, ...args) => {
-  const log = args[0] as IMihomoLogInfo
-  log.time = new Date().toLocaleString()
+const appendLog = (entry: IMihomoLogInfo): void => {
+  const log = { ...entry, time: new Date().toLocaleString() }
   cachedLogs.log.push(log)
   if (cachedLogs.log.length >= 500) {
     cachedLogs.log.shift()
@@ -35,7 +34,7 @@ window.electron.ipcRenderer.on('mihomoLogs', (_e, ...args) => {
   if (cachedLogs.trigger !== null) {
     cachedLogs.trigger(cachedLogs.log)
   }
-})
+}
 
 const Logs: React.FC = () => {
   const { t } = useTranslation()
@@ -63,7 +62,12 @@ const Logs: React.FC = () => {
     cachedLogs.trigger = (a): void => {
       setLogs([...a])
     }
+    const handleLog = (_e: unknown, ...args: unknown[]): void => {
+      appendLog(args[0] as IMihomoLogInfo)
+    }
+    window.electron.ipcRenderer.on('mihomoLogs', handleLog)
     return (): void => {
+      window.electron.ipcRenderer.removeListener('mihomoLogs', handleLog)
       cachedLogs.trigger = old
     }
   }, [])


### PR DESCRIPTION
## Summary
- scope log stream subscriptions to the Logs page lifecycle instead of keeping a renderer-wide listener alive after route import
- remove only the NetworkTopology mihomoConnections handler on cleanup instead of clearing every listener for the channel
- cap in-memory process icon and app-name caches and cancel delayed background path loading on cleanup

## Validation
- PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec eslint src/renderer/src/pages/logs.tsx src/renderer/src/pages/connections.tsx src/renderer/src/components/network/network-topology.tsx
- git diff --check

## Note
Full typecheck currently stops on an existing dependency issue: src/renderer/src/components/base/base-editor.tsx cannot resolve monaco-editor.