### PR TITLE
fix: renderer IPC listener leaks (removeAllListeners misuse + module-level listener)

### DIFF
--- a/src/renderer/src/components/network/network-topology.tsx
+++ b/src/renderer/src/components/network/network-topology.tsx
@@ -267,7 +267,7 @@ const NetworkTopologyCard: React.FC = () => {
     }
     window.electron.ipcRenderer.on('mihomoConnections', handler)
     return () => {
-      window.electron.ipcRenderer.removeAllListeners('mihomoConnections')
+      window.electron.ipcRenderer.removeListener('mihomoConnections', handler)
     }
   }, [isPaused])
 

--- a/src/renderer/src/components/sider/mihomo-core-card.tsx
+++ b/src/renderer/src/components/sider/mihomo-core-card.tsx
@@ -44,13 +44,14 @@ const MihomoCoreCard: React.FC<Props> = (props) => {
     const token = PubSub.subscribe('mihomo-core-changed', () => {
       mutate()
     })
-    window.electron.ipcRenderer.on('mihomoMemory', (_e, ...args) => {
+    const onMemory = (_e: unknown, ...args: unknown[]): void => {
       const info = args[0] as IMihomoMemoryInfo
       setMem(info.inuse)
-    })
+    }
+    window.electron.ipcRenderer.on('mihomoMemory', onMemory)
     return (): void => {
       PubSub.unsubscribe(token)
-      window.electron.ipcRenderer.removeAllListeners('mihomoMemory')
+      window.electron.ipcRenderer.removeListener('mihomoMemory', onMemory)
     }
   }, [mutate])
 

--- a/src/renderer/src/pages/logs.tsx
+++ b/src/renderer/src/pages/logs.tsx
@@ -25,18 +25,6 @@ const cachedLogs: {
   }
 }
 
-window.electron.ipcRenderer.on('mihomoLogs', (_e, ...args) => {
-  const log = args[0] as IMihomoLogInfo
-  log.time = new Date().toLocaleString()
-  cachedLogs.log.push(log)
-  if (cachedLogs.log.length >= 500) {
-    cachedLogs.log.shift()
-  }
-  if (cachedLogs.trigger !== null) {
-    cachedLogs.trigger(cachedLogs.log)
-  }
-})
-
 const Logs: React.FC = () => {
   const { t } = useTranslation()
   const [logs, setLogs] = useState<IMihomoLogInfo[]>(cachedLogs.log)
@@ -63,8 +51,21 @@ const Logs: React.FC = () => {
     cachedLogs.trigger = (a): void => {
       setLogs([...a])
     }
+    const onLog = (_e: unknown, ...args: unknown[]): void => {
+      const log = args[0] as IMihomoLogInfo
+      log.time = new Date().toLocaleString()
+      cachedLogs.log.push(log)
+      if (cachedLogs.log.length >= 500) {
+        cachedLogs.log.shift()
+      }
+      if (cachedLogs.trigger !== null) {
+        cachedLogs.trigger(cachedLogs.log)
+      }
+    }
+    window.electron.ipcRenderer.on('mihomoLogs', onLog)
     return (): void => {
       cachedLogs.trigger = old
+      window.electron.ipcRenderer.removeListener('mihomoLogs', onLog)
     }
   }, [])
 


### PR DESCRIPTION
## Problem

The renderer process exhibits a slow memory growth that keeps increasing while the app is open (\"grows even when idle, after the frontend is loaded\"). Investigation found several IPC listener management bugs that cause leaked/orphaned listeners and redundant processing.

## Root Cause

### 1. \`removeAllListeners\` misuse — silently kills other components' listeners

\`mihomoConnections\` and \`mihomoMemory\` channels are shared by multiple consumers, but two components used \`removeAllListeners(channel)\` in their effect cleanup instead of \`removeListener(channel, handler)\`:

- **\`network-topology.tsx:270\`** — \`mihomoConnections\` is consumed by \`pages/connections.tsx\`, \`hooks/use-traffic-logger.ts\` (mounted at App root), and this card. Calling \`removeAllListeners\` on unmount/pause-toggle **removes the other two consumers' listeners too**, causing the connections page to stop updating and the traffic logger to silently stop recording after visiting the \`/network\` page.
- **\`mihomo-core-card.tsx:53\`** — same misuse on \`mihomoMemory\`. The listener was also an inline anonymous arrow, making precise removal impossible (which is why \`removeAllListeners\` was used as a workaround).

### 2. Module-level IPC listener in \`logs.tsx\` — never cleaned up

\`logs.tsx:28\` registered a \`mihomoLogs\` listener at **module top level** (outside any component/effect). Once the module was imported (first navigation to the logs page), the listener was attached **permanently with no corresponding \`removeListener\`**. The mihomo core log stream is high-frequency, so this listener kept running (parsing, \`new Date().toLocaleString()\`, pushing to the buffer, triggering re-renders) for the entire app lifetime, even after leaving the logs page.

## Fix

- \`network-topology.tsx\`: \`removeAllListeners('mihomoConnections')\` → \`removeListener('mihomoConnections', handler)\` (handler was already named).
- \`mihomo-core-card.tsx\`: extracted the inline listener to a named \`onMemory\`, then \`removeAllListeners('mihomoMemory')\` → \`removeListener('mihomoMemory', onMemory)\`.
- \`logs.tsx\`: moved the \`mihomoLogs\` listener from module scope into the component's \`useEffect\` (merged with the existing trigger-registration effect), and added \`removeListener\` in cleanup. The \`cachedLogs\` module object is preserved to keep the existing cross-render cache and \`clean()\` behavior.

## Behavior change

After this PR, the mihomo log stream is only processed while the Logs page is mounted. Previously it kept running for the whole app lifetime once the Logs page had been visited. This is intentional — the buffer/cache is still preserved across visits via the \`cachedLogs\` module object.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Changes target \`smart_core\` branch
- [x] No new dependencies introduced
- [x] No behavioral regression beyond the documented change above