### PR TITLE
fix: resolve orphaned mihomo core process on session logout and prevent killing unintended processes due to PID reuse in lightweight mode

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -82,6 +82,7 @@ const coreHookTimeout = 30000
 
 // 核心进程状态
 let child: ChildProcess | null = null
+let stoppingChild: ChildProcess | null = null
 let retry = 10
 let isRestarting = false
 
@@ -105,6 +106,37 @@ interface CoreHookWaiter {
 
 function hasCoreProcess(): boolean {
   return Boolean(child && !child.killed && child.exitCode === null && child.signalCode === null)
+}
+
+async function waitForChildExit(proc: ChildProcess, timeout: number): Promise<boolean> {
+  if (proc.exitCode !== null || proc.signalCode !== null) return true
+
+  return new Promise((resolve) => {
+    let completed = false
+    const complete = (exited: boolean): void => {
+      if (completed) return
+      completed = true
+      clearTimeout(timer)
+      proc.off('close', onClose)
+      resolve(exited)
+    }
+    const onClose = (): void => complete(true)
+    const timer = setTimeout(() => complete(false), timeout)
+
+    proc.once('close', onClose)
+    if (proc.exitCode !== null || proc.signalCode !== null) complete(true)
+  })
+}
+
+export async function waitForCoreExit(timeout = 800): Promise<void> {
+  const proc = child ?? stoppingChild
+  if (!proc || (await waitForChildExit(proc, timeout))) return
+
+  try {
+    proc.kill('SIGKILL')
+  } catch {
+    // The process exited after the timeout but before SIGKILL was sent.
+  }
 }
 
 function shellQuote(value: string): string {
@@ -588,7 +620,7 @@ export async function startCore(detached = false, skipStop = false): Promise<Pro
 }
 
 // 停止核心
-export async function stopCore(force = false): Promise<void> {
+export async function stopCore(force = false, waitForExit = false): Promise<void> {
   if (!force && process.platform === 'darwin') {
     try {
       await recoverDNS()
@@ -598,10 +630,17 @@ export async function stopCore(force = false): Promise<void> {
   }
 
   if (child) {
-    child.removeAllListeners()
-    child.kill('SIGINT')
+    const proc = child
+    proc.removeAllListeners()
+    stoppingChild = proc
+    proc.once('close', () => {
+      if (stoppingChild === proc) stoppingChild = null
+    })
+    proc.kill('SIGINT')
     child = null
   }
+
+  if (waitForExit) await waitForCoreExit()
 
   stopMihomoTraffic()
   stopMihomoConnections()

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -54,7 +54,8 @@ import {
   cleanupSocketFile,
   cleanupWindowsNamedPipes,
   validateWindowsPipeAccess,
-  waitForCoreReady
+  waitForCoreReady,
+  verifyProcessOwner
 } from './process'
 import { setPublicDNS, recoverDNS } from './dns'
 
@@ -250,14 +251,18 @@ async function stopPidFileCore(): Promise<void> {
   const pid = parseInt(pidString.trim())
   if (!isNaN(pid)) {
     try {
-      process.kill(pid, 0)
-      process.kill(pid, 'SIGINT')
-      await new Promise((resolve) => setTimeout(resolve, 1000))
-      try {
-        process.kill(pid, 0)
-        process.kill(pid, 'SIGKILL')
-      } catch {
-        // ignore
+      const isOwner = await verifyProcessOwner(pid, 'mihomo')
+      if (isOwner) {
+        process.kill(pid, 'SIGINT')
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        try {
+          process.kill(pid, 0)
+          process.kill(pid, 'SIGKILL')
+        } catch {
+          // ignore
+        }
+      } else {
+        managerLogger.info(`PID ${pid} is not owned by mihomo, skipping kill`)
       }
     } catch {
       // ignore

--- a/src/main/core/process.ts
+++ b/src/main/core/process.ts
@@ -169,3 +169,28 @@ export async function waitForCoreReady(): Promise<void> {
     }
   }
 }
+
+export async function verifyProcessOwner(pid: number, nameMatch: string): Promise<boolean> {
+  try {
+    process.kill(pid, 0)
+  } catch {
+    return false
+  }
+
+  try {
+    if (process.platform === 'win32') {
+      const { stdout } = await execPromise(`tasklist /FI "PID eq ${pid}" /FO CSV /NH`, {
+        windowsHide: true,
+        timeout: 1000
+      })
+      return stdout.toLowerCase().includes(nameMatch.toLowerCase())
+    } else {
+      // 使用 `comm=` 参数最多可显示 15 字符，超出会截断；TrafficMonitor 为 14 字符，可用
+      const { stdout } = await execPromise(`ps -p ${pid} -o comm=`, { timeout: 1000 })
+      return stdout.toLowerCase().includes(nameMatch.toLowerCase())
+    }
+  } catch {
+    return false
+  }
+}
+

--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util'
 import { stat } from 'fs/promises'
 import { existsSync } from 'fs'
 import { app, powerMonitor } from 'electron'
-import { stopCore, cleanupCoreWatcher } from './core/manager'
+import { stopCore, cleanupCoreWatcher, waitForCoreExit } from './core/manager'
 import { primeAdminPrivilegesCache } from './core/admin'
 import { triggerSysProxy, disableSysProxySync } from './sys/sysproxy'
 import { exePath } from './utils/dirs'
@@ -95,8 +95,11 @@ export function setupAppLifecycle(): void {
     }
   }
 
-  const cleanupBeforeExit = async (): Promise<void> => {
-    if (isQuitting) return
+  const cleanupBeforeExit = async (waitForCoreShutdown = false): Promise<void> => {
+    if (isQuitting) {
+      if (waitForCoreShutdown) await waitForCoreExit()
+      return
+    }
     isQuitting = true
 
     saveMainWindowState() // 硬退出补一次落盘
@@ -113,7 +116,7 @@ export function setupAppLifecycle(): void {
         triggerSysProxy(false).then(() => {
           sysProxyDisabled = true
         }),
-        stopCore()
+        stopCore(false, waitForCoreShutdown)
       ]).then(() => {}),
       1200
     )
@@ -133,6 +136,12 @@ export function setupAppLifecycle(): void {
     await cleanupBeforeExit()
     app.exit()
   })
+
+  if (process.platform === 'linux') {
+    process.once('SIGTERM', () => {
+      void cleanupBeforeExit(true).finally(() => app.exit())
+    })
+  }
 
   app.on('will-quit', () => {
     if (!sysProxyDisabled) {

--- a/src/main/resolve/trafficMonitor.ts
+++ b/src/main/resolve/trafficMonitor.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'fs'
 import { readFile, rm, writeFile } from 'fs/promises'
 import { dataDir, resourcesFilesDir } from '../utils/dirs'
 import { getAppConfig } from '../config'
+import { verifyProcessOwner } from '../core/process'
 
 let child: ChildProcess
 
@@ -12,7 +13,12 @@ export async function startMonitor(detached = false): Promise<void> {
   if (existsSync(path.join(dataDir(), 'monitor.pid'))) {
     const pid = parseInt(await readFile(path.join(dataDir(), 'monitor.pid'), 'utf-8'))
     try {
-      process.kill(pid, 'SIGINT')
+      if (!isNaN(pid)) {
+        const isOwner = await verifyProcessOwner(pid, 'TrafficMonitor')
+        if (isOwner) {
+          process.kill(pid, 'SIGINT')
+        }
+      }
     } catch {
       // ignore
     } finally {


### PR DESCRIPTION
Closes: #1981

## 该 PR 中第一个提交涉及到应用核心代码的改动，需要大家细致的 review

该 PR 解决了两个问题：

### 1. linux 系统登出导致 mihomo 内核成为孤儿进程

#### 原因

Electron (Node.js) 主进程在接收到未捕获的 SIGTERM 时，默认行为是立即终止。这导致它跳过了 Electron 的正常退出生命周期（如 before-quit 和 will-quit），无法执行 `cleanupBeforeExit()`。

#### 解决方法

新增了对 SIGTERM 信号的监听器，一旦为 SIGTERM 注册了监听器，Electron 收到该信号时就不会立即退出，而是把控制权交给监听器回调。

监听器中，执行异步的 `cleanupBeforeExit(true)`（传入 true 表示需要等待内核退出），当清理工作全部完成后（无论成功还是超时失败），通过 `.finally()` 调用 `app.exit()` 真正退出 Electron 主进程。

新增了 `waitForChildExit` 和 `waitForCoreExit`，并引入了 `stoppingChild` 变量。

`stopCore` 首先向 mihomo 发送 SIGINT。`waitForCoreExit` 设定了 800ms 的最大等待阈值。如果内核在这个时间内没有退出（`waitForChildExit` 返回 false），主进程会强制使用 SIGKILL 暴力杀死它。这避免了内核在卡死时无限阻塞系统注销流程。

在注册 `once('close')` 后，立即再次检查进程的 exitCode 和 signalCode，防止在监听器挂载瞬间进程已经结束而导致的挂起。

### 2. 轻量模式有可能误杀复用了 mihomo 等进程 PID 的其他进程

#### 原因

当客户端开启轻量模式（仅保留核心）时，`src/main/core/manager.ts` 会将运行中的 mihomo 进程的 PID 写入 core.pid。如果在 Windows 开启了悬浮窗，`src/main/resolve/trafficMonitor.ts` 也会将流量监控应用的 PID 写入 monitor.pid。

- 场景1：在轻量模式下，内核/悬浮窗进程意外崩溃或被用户误杀掉，该 PID 就会被释放，操作系统有可能复用该 PID，将其重新分配给另一个应用。
- **场景2：更为严重的是，应用进入了轻量模式，用户直接进行了关机后，PID 文件仍然存在硬盘中，但下次开机后，该 PID 对应的进程完全不可预测。**

当用户下次启动图形化应用时，`stopPidFileCore` 和 `startMonitor` 函数会无脑读取旧的 .pid 文件，并对其执行 `process.kill(pid, 'SIGINT')` 甚至 SIGKILL，从而有可能意外杀掉完全无辜的其它进程。**这种情况在场景2中极有可能出现。**

#### 解决方法

在发送 kill 信号之前，先通过系统原生的命令核对对应 PID 运行的进程名是否符合预期。新增跨平台的 `verifyProcessOwner` 方法，利用操作系统自带工具查询并验证 PID。

- Windows: 使用 `tasklist /FI "PID eq <pid>"`
- macOS / Linux: 使用 `ps -p <pid> -o comm=`