### PR TITLE
fix: prevent killing unintended processes due to PID reuse in lightweight mode

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -54,7 +54,8 @@ import {
   cleanupSocketFile,
   cleanupWindowsNamedPipes,
   validateWindowsPipeAccess,
-  waitForCoreReady
+  waitForCoreReady,
+  verifyProcessOwner
 } from './process'
 import { setPublicDNS, recoverDNS } from './dns'
 
@@ -218,14 +219,18 @@ async function stopPidFileCore(): Promise<void> {
   const pid = parseInt(pidString.trim())
   if (!isNaN(pid)) {
     try {
-      process.kill(pid, 0)
-      process.kill(pid, 'SIGINT')
-      await new Promise((resolve) => setTimeout(resolve, 1000))
-      try {
-        process.kill(pid, 0)
-        process.kill(pid, 'SIGKILL')
-      } catch {
-        // ignore
+      const isOwner = await verifyProcessOwner(pid, 'mihomo')
+      if (isOwner) {
+        process.kill(pid, 'SIGINT')
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        try {
+          process.kill(pid, 0)
+          process.kill(pid, 'SIGKILL')
+        } catch {
+          // ignore
+        }
+      } else {
+        managerLogger.info(`PID ${pid} is not owned by mihomo, skipping kill`)
       }
     } catch {
       // ignore

--- a/src/main/core/process.ts
+++ b/src/main/core/process.ts
@@ -169,3 +169,28 @@ export async function waitForCoreReady(): Promise<void> {
     }
   }
 }
+
+export async function verifyProcessOwner(pid: number, nameMatch: string): Promise<boolean> {
+  try {
+    process.kill(pid, 0)
+  } catch {
+    return false
+  }
+
+  try {
+    if (process.platform === 'win32') {
+      const { stdout } = await execPromise(`tasklist /FI "PID eq ${pid}" /FO CSV /NH`, {
+        windowsHide: true,
+        timeout: 1000
+      })
+      return stdout.toLowerCase().includes(nameMatch.toLowerCase())
+    } else {
+      // 使用 `comm=` 参数最多可显示 15 字符，超出会截断；TrafficMonitor 为 14 字符，可用
+      const { stdout } = await execPromise(`ps -p ${pid} -o comm=`, { timeout: 1000 })
+      return stdout.toLowerCase().includes(nameMatch.toLowerCase())
+    }
+  } catch {
+    return false
+  }
+}
+

--- a/src/main/resolve/trafficMonitor.ts
+++ b/src/main/resolve/trafficMonitor.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'fs'
 import { readFile, rm, writeFile } from 'fs/promises'
 import { dataDir, resourcesFilesDir } from '../utils/dirs'
 import { getAppConfig } from '../config'
+import { verifyProcessOwner } from '../core/process'
 
 let child: ChildProcess
 
@@ -12,7 +13,12 @@ export async function startMonitor(detached = false): Promise<void> {
   if (existsSync(path.join(dataDir(), 'monitor.pid'))) {
     const pid = parseInt(await readFile(path.join(dataDir(), 'monitor.pid'), 'utf-8'))
     try {
-      process.kill(pid, 'SIGINT')
+      if (!isNaN(pid)) {
+        const isOwner = await verifyProcessOwner(pid, 'TrafficMonitor')
+        if (isOwner) {
+          process.kill(pid, 'SIGINT')
+        }
+      }
     } catch {
       // ignore
     } finally {


### PR DESCRIPTION
## 问题描述

轻量模式（仅保留核心）下，图形化客户端有可能误杀复用了 mihomo 等进程 PID 的其他进程

### 原因

当客户端开启轻量模式（仅保留核心）时，`src/main/core/manager.ts` 会将运行中的 mihomo 进程的 PID 写入 core.pid。

如果在 Windows 开启了悬浮窗，`src/main/resolve/trafficMonitor.ts` 也会将流量监控应用的 PID 写入 monitor.pid。

当用户下次启动图形化应用时，`stopPidFileCore` 和 `startMonitor` 函数会无脑读取旧的 .pid 文件，并对其执行 `process.kill(pid, 'SIGINT')` 甚至 SIGKILL，从而有可能意外杀掉完全无辜的其它进程。

具体场景如下：

- 场景1：在轻量模式下，内核/悬浮窗进程意外崩溃或被用户误杀掉，该 PID 就会被释放，操作系统有可能复用该 PID，将其重新分配给另一个应用。
- **场景2：更为严重的是，应用进入了轻量模式，用户直接进行了关机后，PID 文件仍然存在硬盘中，但下次开机后，该 PID 对应的进程完全不可预测。**

### 解决方法

在发送 kill 信号之前，先通过系统原生的命令核对对应 PID 运行的进程名是否符合预期。新增跨平台的 `verifyProcessOwner` 方法，利用操作系统自带工具查询并验证 PID。

- Windows: 使用 `tasklist /FI "PID eq <pid>"`
- macOS / Linux: 使用 `ps -p <pid> -o comm=`