### PR TITLE
fix: resolve orphaned mihomo core process on session logout

### DIFF
--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -82,6 +82,7 @@ const coreHookTimeout = 30000
 
 // 核心进程状态
 let child: ChildProcess | null = null
+let coreWatchdog: ChildProcess | null = null
 let retry = 10
 let isRestarting = false
 
@@ -574,6 +575,14 @@ export async function startCore(detached = false, skipStop = false): Promise<Pro
   hookWaiter?.attachProcess(proc)
   child = proc
 
+  if (process.platform === 'linux' && !detached) {
+    coreWatchdog = spawn('sh', ['-c', `cat > /dev/null; kill -9 ${proc.pid} 2>/dev/null`], {
+      stdio: ['pipe', 'ignore', 'ignore'],
+      detached: true
+    })
+    coreWatchdog.unref()
+  }
+
   if (detached) {
     managerLogger.info(
       `Core process detached successfully on ${process.platform}, PID: ${proc.pid}`
@@ -601,6 +610,15 @@ export async function stopCore(force = false): Promise<void> {
     child.removeAllListeners()
     child.kill('SIGINT')
     child = null
+  }
+
+  if (coreWatchdog && coreWatchdog.pid) {
+    try {
+      process.kill(-coreWatchdog.pid, 'SIGKILL')
+    } catch (e) {
+      // Ignore
+    }
+    coreWatchdog = null
   }
 
   stopMihomoTraffic()


### PR DESCRIPTION
Closes: https://github.com/mihomo-party-org/clash-party/issues/1981

经过构建测试，PR #1989 中的解决方法无法彻底解决问题，转而使用了看门狗。

### 问题的根本原因 (Issue #1981)
在 Linux 系统中，如果用户没有手动退出 `clash-party` 就直接注销（Logout）操作系统，Linux 系统的会话管理器会强行杀掉 Electron 主进程。

因为主进程被瞬间杀死，它内部配置的资源清理函数（如 `cleanupBeforeExit`）由于是异步操作，根本**来不及执行**就结束了。

这导致由主进程启动的 `mihomo` 内核进程并没有被杀死，而是被 init 进程接管，成为了**孤儿进程**并在后台继续运行。

由于这个孤儿进程仍然占用着 7890、7891 等代理端口，当用户再次登录并打开 `clash-party` 时，新的内核进程就会因为**端口被占用**而无法启动，导致程序长时间阻塞重试并最终报错，同时丧失了对内核的控制。

### 解决方案
在 `src/main/core/manager.ts` 中针对 Linux 平台利用 Unix 管道（Pipe）的系统特性实现了一个看门狗：

```typescript
  if (process.platform === 'linux' && !detached) {
    // 启动看门狗进程
    coreWatchdog = spawn('sh', ['-c', `cat > /dev/null; kill -9 ${proc.pid} 2>/dev/null`], {
      stdio: ['pipe', 'ignore', 'ignore'],
      detached: true
    })
    coreWatchdog.unref()
  }
```

**原理：**
1. **创建管道绑定：** 当主进程启动 `mihomo` 内核后，额外衍生出一个后台 Shell 进程（即 `coreWatchdog`）。并且通过 `stdio: ['pipe', ...]` 在主进程和看门狗进程之间建立了一个标准输入管道。
2. **`cat` 阻塞等待：** Shell 进程执行的第一条命令是 `cat > /dev/null`。`cat` 会一直尝试从刚刚建立的管道中读取数据，只要 Electron 主进程还活着，管道就会保持打开状态，`cat` 命令就会一直**阻塞**在这里。
3. **系统自动回收：** 当系统注销，Electron 主进程被操作系统强杀时，操作系统在内核层面会自动关闭该进程分配的所有文件描述符（包括与 `cat` 通信的这个管道）。
4. **触发清理动作：** 管道被关闭后，`cat` 命令会立即收到 `EOF` (文件结束符) 并退出。随后，Shell 进程会继续执行下一条命令：`kill -9 ${proc.pid}`。
5. **精准击杀内核：** 此时 `kill -9` 被触发，向残留的 `mihomo` 内核进程发送 `SIGKILL` 强制终止信号。

**补充处理：**
在正常的退出逻辑 `stopCore()` 函数中，也补充了对看门狗进程的清理：
```typescript
  if (coreWatchdog && coreWatchdog.pid) {
    try {
      process.kill(-coreWatchdog.pid, 'SIGKILL')
    } catch (e) {
      // Ignore
    }
    coreWatchdog = null
  }
```
如果在正常使用中手动退出程序，程序会主动杀掉这个看门狗，避免留下多余的守护进程。

### 总结

该方案**不再依赖 Node.js 事件循环中的异步清理代码**，而是将其交给了 Linux 操作系统的底层文件描述符生命周期管理。

开销极小，`cat` 进程启动后，由于并没有数据写入管道，它会一直阻塞在底层的 `read()` 系统调用上被操作系统挂起，在触发清理前 CPU 占用严格为 0。

无论是：
- Electron 主进程因为注销被系统强杀
- Linux 桌面环境崩溃
- 图形化进程本身因为某些原因崩溃

操作系统断开管道的行为都是百分之百确定会发生的，从而确保 `mihomo` 内核必定会被看门狗进程一起清理掉，彻底根治了产生孤儿进程和端口占用的问题。
