### PR TITLE
feat: redesign airport plugin UI & support per-plugin proxy settings

### DIFF
--- a/src/main/config/plugin.test.ts
+++ b/src/main/config/plugin.test.ts
@@ -1,16 +1,20 @@
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 let TMP = ''
-vi.mock('../utils/dirs', () => ({ pluginConfigPath: () => join(TMP, 'plugin.yaml') }))
+vi.mock('../utils/dirs', () => ({
+  pluginConfigPath: () => join(TMP, 'plugin.yaml'),
+  appConfigPath: () => join(TMP, 'app.yaml')
+}))
 
 import {
   getPluginConfig,
   addPluginItem,
   getPluginItem,
   updatePluginItem,
+  patchPluginItem,
   removePluginItem
 } from './plugin'
 
@@ -29,6 +33,7 @@ function item(id: string): IPluginItem {
 
 beforeEach(() => {
   TMP = mkdtempSync(join(tmpdir(), 'cpxcfg-'))
+  writeFileSync(join(TMP, 'app.yaml'), '{}')
 })
 afterEach(() => rmSync(TMP, { recursive: true, force: true }))
 
@@ -45,6 +50,11 @@ describe('plugin config CRUD', () => {
     await addPluginItem(item('a'))
     await updatePluginItem({ ...item('a'), status: 'needs-reauth' })
     expect((await getPluginItem('a'))?.status).toBe('needs-reauth')
+  })
+  it('patches an item', async () => {
+    await addPluginItem(item('a'))
+    await patchPluginItem('a', { useProxy: true })
+    expect((await getPluginItem('a'))?.useProxy).toBe(true)
   })
   it('removes an item', async () => {
     await addPluginItem(item('a'))

--- a/src/main/config/plugin.ts
+++ b/src/main/config/plugin.ts
@@ -53,6 +53,15 @@ export async function updatePluginItem(newItem: IPluginItem): Promise<void> {
   })
 }
 
+export async function patchPluginItem(id: string, patch: Partial<IPluginItem>): Promise<void> {
+  await update((c) => {
+    const idx = c.items.findIndex((i) => i.id === id)
+    if (idx === -1) throw new Error('Plugin not found')
+    c.items[idx] = { ...c.items[idx], ...patch }
+    return c
+  })
+}
+
 export async function removePluginItem(id: string): Promise<void> {
   await update((c) => {
     c.items = c.items.filter((i) => i.id !== id)

--- a/src/main/resolve/plugin/index.ts
+++ b/src/main/resolve/plugin/index.ts
@@ -3,7 +3,8 @@ import {
   getPluginItem,
   addPluginItem,
   updatePluginItem,
-  removePluginItem
+  removePluginItem,
+  patchPluginItem as patchConfig
 } from '../../config/plugin'
 import { upsertPluginProfile, removePluginProfileContent } from '../../config/profile'
 import { getAppConfig } from '../../config/app'
@@ -37,9 +38,11 @@ interface NetOpts {
   proxy?: { host: string; port: number }
 }
 
-async function netOpts(): Promise<NetOpts> {
-  const { subscriptionTimeout = 30000, pluginUseProxy } = await getAppConfig()
-  if (!pluginUseProxy) return { timeout: subscriptionTimeout }
+async function netOpts(item?: IPluginItem): Promise<NetOpts> {
+  const { subscriptionTimeout = 30000, pluginUseProxy: globalUseProxy = false } =
+    await getAppConfig()
+  const useProxy = typeof item?.useProxy === 'boolean' ? item.useProxy : globalUseProxy
+  if (!useProxy) return { timeout: subscriptionTimeout }
   const { getControledMihomoConfig } = await import('../../config/controledMihomo')
   const { 'mixed-port': port = 7890 } = await getControledMihomoConfig()
   return { timeout: subscriptionTimeout, proxy: { host: '127.0.0.1', port } }
@@ -68,6 +71,7 @@ export async function previewPlugin(fileBytesB64: string): Promise<IPluginDescri
 // 安装：解析 + 建 needs-login 记录（无 profileId、不联网）
 export async function installPlugin(fileBytesB64: string): Promise<IPluginItem> {
   const d = readDescriptor(fileBytesB64)
+  const { pluginUseProxy = false } = await getAppConfig()
   const now = Date.now()
   const record: IPluginItem = {
     id: randomUUID(),
@@ -79,6 +83,7 @@ export async function installPlugin(fileBytesB64: string): Promise<IPluginItem> 
     status: 'needs-login',
     interval: DEFAULT_PLUGIN_INTERVAL_MIN,
     autoUpdate: true,
+    useProxy: pluginUseProxy,
     created: now,
     updated: now
   }
@@ -141,7 +146,7 @@ export async function loginPlugin(id: string): Promise<void> {
 async function runLogin(id: string): Promise<void> {
   const record = await getPluginItem(id)
   if (!record) throw new Error('Plugin not found')
-  const net = await netOpts()
+  const net = await netOpts(record)
 
   const existingResult = await readVault(id)
   if (existingResult.kind === 'unavailable') throw new VaultUnavailableError()
@@ -286,7 +291,7 @@ export async function updatePluginProfile(id: string, force = false): Promise<vo
     return
   }
   const vault = vaultResult.vault
-  const net = await netOpts()
+  const net = await netOpts(record)
   try {
     const content = await fetchWithRediscovery(id, record, vault, net)
     await upsertPluginProfile(
@@ -348,7 +353,7 @@ export async function revokePluginDevice(id: string): Promise<void> {
   const vault = vaultResult.vault
   const record = await getPluginItem(id)
   const cred = { deviceId: vault.deviceId, privKeyB64: vault.devicePrivKey }
-  const net = await netOpts()
+  const net = await netOpts(record ?? undefined)
   try {
     // 网关轮换后旧 gateway 可能 retired/unreachable：用 loginUrl 重新发现再 revoke，避免设备绑定残留
     if (record) {
@@ -371,5 +376,10 @@ export async function removePlugin(id: string): Promise<void> {
   await removeVault(id)
   if (record?.profileId) await removePluginProfileContent(record.profileId)
   await removePluginItem(id)
+  notifyRenderer()
+}
+
+export async function patchPluginItem(id: string, patch: Partial<IPluginItem>): Promise<void> {
+  await patchConfig(id, patch)
   notifyRenderer()
 }

--- a/src/main/utils/ipc.ts
+++ b/src/main/utils/ipc.ts
@@ -128,7 +128,8 @@ import {
   installPlugin,
   loginPlugin,
   removePlugin,
-  updatePluginProfile
+  updatePluginProfile,
+  patchPluginItem
 } from '../resolve/plugin'
 import { getPluginConfig } from '../config/plugin'
 import { getImageDataURL } from './image'
@@ -357,6 +358,7 @@ const asyncHandlers: Record<string, AsyncFn> = {
   loginPlugin,
   removePlugin,
   updatePluginProfile,
+  patchPluginItem,
   // Misc
   getGistUrl,
   generateGistAgeKeyPair,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -153,6 +153,7 @@ const validInvokeChannels = [
   'loginPlugin',
   'removePlugin',
   'updatePluginProfile',
+  'patchPluginItem',
   // Misc
   'getGistUrl',
   'generateGistAgeKeyPair',

--- a/src/renderer/src/components/plugins/plugin-install-modal.tsx
+++ b/src/renderer/src/components/plugins/plugin-install-modal.tsx
@@ -23,9 +23,16 @@ interface Props {
 const MAX_CPX_BYTES = 10 * 1024 * 1024 // guard against a huge mis-dropped file freezing the renderer
 
 function abToBase64(buf: ArrayBuffer): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(buf).toString('base64')
+  }
   let binary = ''
   const bytes = new Uint8Array(buf)
-  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize)
+    binary += String.fromCharCode.apply(null, chunk as unknown as number[])
+  }
   return btoa(binary)
 }
 

--- a/src/renderer/src/components/plugins/plugin-install-modal.tsx
+++ b/src/renderer/src/components/plugins/plugin-install-modal.tsx
@@ -1,8 +1,18 @@
-import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button } from '@heroui/react'
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Checkbox,
+  Tooltip
+} from '@heroui/react'
 import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from '@renderer/components/base/toast'
 import { previewPlugin, installPlugin } from '@renderer/utils/ipc'
+import { useAppConfig } from '@renderer/hooks/use-app-config'
 
 interface Props {
   onClose: () => void
@@ -29,6 +39,9 @@ function hostOf(url: string): string {
 
 const PluginInstallModal: React.FC<Props> = ({ onClose, initialFile, initialData }) => {
   const { t } = useTranslation()
+
+  const { appConfig, patchAppConfig } = useAppConfig()
+  const pluginUseProxy = appConfig?.pluginUseProxy ?? false
   const fileInput = useRef<HTMLInputElement>(null)
   const [fileName, setFileName] = useState('')
   const [fileB64, setFileB64] = useState('')
@@ -104,22 +117,37 @@ const PluginInstallModal: React.FC<Props> = ({ onClose, initialFile, initialData
   }
 
   return (
-    <Modal isOpen onOpenChange={(open) => !open && onClose()} size="md">
+    <Modal
+      backdrop="blur"
+      classNames={{ backdrop: 'top-[48px]' }}
+      isOpen
+      hideCloseButton
+      onOpenChange={(open) => !open && onClose()}
+      size="md"
+    >
       <ModalContent>
-        <ModalHeader>{preview ? t('plugins.confirmTitle') : t('plugins.import')}</ModalHeader>
+        <ModalHeader>{preview ? t('plugins.confirmTitle') : t('plugins.title')}</ModalHeader>
         <ModalBody>
           {!preview ? (
-            <div className="flex flex-col gap-3">
-              <input
-                ref={fileInput}
-                type="file"
-                accept=".cpx"
-                className="hidden"
-                onChange={onPickFile}
-              />
-              <Button variant="flat" isDisabled={busy} onPress={() => fileInput.current?.click()}>
-                {fileName || t('plugins.chooseFile')}
-              </Button>
+            <div className="flex flex-col gap-4">
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium">{t('plugins.import')}</span>
+                <input
+                  ref={fileInput}
+                  type="file"
+                  accept=".cpx"
+                  className="hidden"
+                  onChange={onPickFile}
+                />
+                <Button
+                  variant="flat"
+                  size="sm"
+                  isDisabled={busy}
+                  onPress={() => fileInput.current?.click()}
+                >
+                  {fileName || t('plugins.chooseFile')}
+                </Button>
+              </div>
             </div>
           ) : (
             <div className="flex flex-col gap-2 text-sm">
@@ -138,19 +166,30 @@ const PluginInstallModal: React.FC<Props> = ({ onClose, initialFile, initialData
             </div>
           )}
         </ModalBody>
-        <ModalFooter>
-          <Button variant="light" onPress={onClose}>
-            {t('plugins.cancel')}
-          </Button>
-          {!preview ? (
-            <Button color="primary" isLoading={busy} isDisabled={!fileB64} onPress={doPreview}>
-              {t('plugins.next')}
+        <ModalFooter className="flex items-center justify-between">
+          <Tooltip content={t('plugins.useProxyWarning')} placement="bottom">
+            <Checkbox
+              size="sm"
+              isSelected={pluginUseProxy}
+              onValueChange={(v) => patchAppConfig({ pluginUseProxy: v })}
+            >
+              {t('plugins.useProxy')}
+            </Checkbox>
+          </Tooltip>
+          <div className="flex items-center gap-2">
+            <Button variant="light" onPress={onClose}>
+              {t('plugins.cancel')}
             </Button>
-          ) : (
-            <Button color="primary" isLoading={busy} onPress={doInstall}>
-              {t('plugins.install')}
-            </Button>
-          )}
+            {!preview ? (
+              <Button color="primary" isLoading={busy} isDisabled={!fileB64} onPress={doPreview}>
+                {t('plugins.next')}
+              </Button>
+            ) : (
+              <Button color="primary" isLoading={busy} onPress={doInstall}>
+                {t('plugins.install')}
+              </Button>
+            )}
+          </div>
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/src/renderer/src/components/plugins/plugin-item.tsx
+++ b/src/renderer/src/components/plugins/plugin-item.tsx
@@ -1,10 +1,11 @@
-import { Card, CardBody, Chip, Button } from '@heroui/react'
+import { Card, CardBody, Chip, Button, Checkbox, Tooltip } from '@heroui/react'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from '@renderer/components/base/toast'
-import { removePlugin, loginPlugin } from '@renderer/utils/ipc'
+import { removePlugin, loginPlugin, patchPluginItem } from '@renderer/utils/ipc'
 import BaseConfirmModal from '@renderer/components/base/base-confirm-modal'
 import { TbPuzzle } from 'react-icons/tb'
+import { useAppConfig } from '@renderer/hooks/use-app-config'
 
 interface Props {
   item: IPluginItem
@@ -19,6 +20,10 @@ const statusColor: Record<IPluginStatus, 'success' | 'warning' | 'primary'> = {
 
 const PluginItem: React.FC<Props> = ({ item, onChanged }) => {
   const { t } = useTranslation()
+  const { appConfig } = useAppConfig()
+  const useProxy =
+    typeof item.useProxy === 'boolean' ? item.useProxy : (appConfig?.pluginUseProxy ?? false)
+
   const [busy, setBusy] = useState(false)
   const [showRemove, setShowRemove] = useState(false)
 
@@ -36,40 +41,58 @@ const PluginItem: React.FC<Props> = ({ item, onChanged }) => {
     }
   }
 
+  const handleProxyChange = async (v: boolean): Promise<void> => {
+    try {
+      await patchPluginItem(item.id, { useProxy: v })
+      onChanged()
+    } catch (e) {
+      toast.error(String(e))
+    }
+  }
+
   const needsLogin = item.status === 'needs-login'
   const needsReauth = item.status === 'needs-reauth'
 
   return (
-    <Card>
-      <CardBody className="flex flex-col gap-2">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5 text-primary">
-            <TbPuzzle className="text-lg" />
-            <span className="font-bold text-foreground">{item.name}</span>
+    <Card className="overflow-hidden">
+      <CardBody className="flex flex-col gap-2 overflow-x-hidden">
+        <div className="flex items-center justify-between gap-2 min-w-0">
+          <div className="flex items-center gap-1.5 text-primary min-w-0">
+            <TbPuzzle className="text-lg flex-shrink-0" />
+            <span className="font-bold text-foreground truncate">{item.name}</span>
           </div>
-          <Chip size="sm" color={statusColor[item.status]}>
+          <Chip size="sm" color={statusColor[item.status]} className="flex-shrink-0">
             {t(`plugins.status.${item.status}`)}
           </Chip>
         </div>
-        <span className="text-xs text-foreground-500">{item.loginUrl}</span>
+        <span className="text-xs text-foreground-500 truncate" title={item.loginUrl}>
+          {item.loginUrl}
+        </span>
 
         {needsLogin && <div className="text-xs text-primary">{t('plugins.needsLoginTip')}</div>}
         {needsReauth && <div className="text-xs text-warning">{t('plugins.reauthTip')}</div>}
 
-        <div className="flex gap-2 flex-wrap">
-          {needsLogin && (
-            <Button size="sm" color="primary" isLoading={busy} onPress={doLogin}>
-              {t('plugins.login')}
+        <div className="flex items-center justify-between gap-2 flex-wrap min-w-0">
+          <div className="flex items-center gap-2">
+            {needsLogin && (
+              <Button size="sm" color="primary" isLoading={busy} onPress={doLogin}>
+                {t('plugins.login')}
+              </Button>
+            )}
+            {needsReauth && (
+              <Button size="sm" color="warning" isLoading={busy} onPress={doLogin}>
+                {t('plugins.relogin')}
+              </Button>
+            )}
+            <Button size="sm" variant="flat" color="danger" onPress={() => setShowRemove(true)}>
+              {t('plugins.remove')}
             </Button>
-          )}
-          {needsReauth && (
-            <Button size="sm" color="warning" isLoading={busy} onPress={doLogin}>
-              {t('plugins.relogin')}
-            </Button>
-          )}
-          <Button size="sm" variant="flat" color="danger" onPress={() => setShowRemove(true)}>
-            {t('plugins.remove')}
-          </Button>
+          </div>
+          <Tooltip content={t('plugins.useProxyWarning')} placement="bottom">
+            <Checkbox size="sm" isSelected={useProxy} onValueChange={handleProxyChange}>
+              {t('plugins.useProxy')}
+            </Checkbox>
+          </Tooltip>
         </div>
       </CardBody>
 

--- a/src/renderer/src/components/plugins/plugin-item.tsx
+++ b/src/renderer/src/components/plugins/plugin-item.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { toast } from '@renderer/components/base/toast'
 import { removePlugin, loginPlugin } from '@renderer/utils/ipc'
 import BaseConfirmModal from '@renderer/components/base/base-confirm-modal'
+import { TbPuzzle } from 'react-icons/tb'
 
 interface Props {
   item: IPluginItem
@@ -42,7 +43,10 @@ const PluginItem: React.FC<Props> = ({ item, onChanged }) => {
     <Card>
       <CardBody className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
-          <span className="font-bold">{item.name}</span>
+          <div className="flex items-center gap-1.5 text-primary">
+            <TbPuzzle className="text-lg" />
+            <span className="font-bold text-foreground">{item.name}</span>
+          </div>
           <Chip size="sm" color={statusColor[item.status]}>
             {t(`plugins.status.${item.status}`)}
           </Chip>

--- a/src/renderer/src/locales/zh-CN.json
+++ b/src/renderer/src/locales/zh-CN.json
@@ -828,7 +828,11 @@
     "useProxyWarning": "插件请求经由本地混合端口代理发出。仍校验 https、主机、重定向和大小，但无法验证代理最终解析到的 IP，SSRF 防护降级。",
     "remove": "删除",
     "removeConfirm": "确认删除该插件及其订阅？",
-    "status": { "needs-login": "待登录", "active": "正常", "needs-reauth": "需重新登录" },
+    "status": {
+      "needs-login": "待登录",
+      "active": "正常",
+      "needs-reauth": "需重新登录"
+    },
     "installed": "已安装",
     "installFailed": "安装失败",
     "previewFailed": "插件文件无效",

--- a/src/renderer/src/locales/zh-TW.json
+++ b/src/renderer/src/locales/zh-TW.json
@@ -828,7 +828,11 @@
     "useProxyWarning": "外掛請求經由本機混合埠代理發出。仍校驗 https、主機、重新導向與大小，但無法驗證代理最終解析到的 IP，SSRF 防護降級。",
     "remove": "刪除",
     "removeConfirm": "確認刪除該外掛及其訂閱？",
-    "status": { "needs-login": "待登入", "active": "正常", "needs-reauth": "需重新登入" },
+    "status": {
+      "needs-login": "待登入",
+      "active": "正常",
+      "needs-reauth": "需重新登入"
+    },
     "installed": "已安裝",
     "installFailed": "安裝失敗",
     "previewFailed": "外掛檔案無效",

--- a/src/renderer/src/pages/profiles.tsx
+++ b/src/renderer/src/pages/profiles.tsx
@@ -29,6 +29,7 @@ import {
 import type { KeyboardEvent } from 'react'
 import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { MdContentPaste, MdUnfoldMore, MdUnfoldLess } from 'react-icons/md'
+import { TbPuzzle } from 'react-icons/tb'
 import {
   DndContext,
   closestCenter,
@@ -58,12 +59,11 @@ const Profiles: React.FC = () => {
     changeCurrentProfile,
     mutateProfileConfig
   } = useProfileConfig()
-  const { appConfig, patchAppConfig } = useAppConfig()
+  const { appConfig } = useAppConfig()
   const {
     useSubStore = DEFAULT_USE_SUB_STORE,
     useCustomSubStore = false,
-    customSubStoreUrl = '',
-    pluginUseProxy = false
+    customSubStoreUrl = ''
   } = appConfig || {}
   const { current, items = [] } = profileConfig || {}
   const navigate = useNavigate()
@@ -284,31 +284,47 @@ const Profiles: React.FC = () => {
       ref={pageRef}
       title={t('profiles.title')}
       header={
-        <Button
-          size="sm"
-          title={t('profiles.updateAll')}
-          className="app-nodrag"
-          variant="light"
-          isIconOnly
-          onPress={async () => {
-            setUpdating(true)
-            for (const item of items) {
-              if (item.id === current) continue
-              if (item.type === 'remote') await addProfileItem(item)
-              else if (item.type === 'plugin' && item.pluginId)
-                await updatePluginProfile(item.pluginId, true)
-            }
-            const currentItem = items.find((item) => item.id === current)
-            if (currentItem && currentItem.type === 'remote') {
-              await addProfileItem(currentItem)
-            } else if (currentItem?.type === 'plugin' && currentItem.pluginId) {
-              await updatePluginProfile(currentItem.pluginId, true)
-            }
-            setUpdating(false)
-          }}
-        >
-          <IoMdRefresh className={`text-lg ${updating ? 'animate-spin' : ''}`} />
-        </Button>
+        <>
+          <Button
+            size="sm"
+            title={t('plugins.title')}
+            isIconOnly
+            variant="light"
+            className="app-nodrag"
+            onPress={() => {
+              setPluginDropFile(null)
+              setPluginFileData(null)
+              setShowPluginImport(true)
+            }}
+          >
+            <TbPuzzle className="text-lg" />
+          </Button>
+          <Button
+            size="sm"
+            title={t('profiles.updateAll')}
+            className="app-nodrag"
+            variant="light"
+            isIconOnly
+            onPress={async () => {
+              setUpdating(true)
+              for (const item of items) {
+                if (item.id === current) continue
+                if (item.type === 'remote') await addProfileItem(item)
+                else if (item.type === 'plugin' && item.pluginId)
+                  await updatePluginProfile(item.pluginId, true)
+              }
+              const currentItem = items.find((item) => item.id === current)
+              if (currentItem && currentItem.type === 'remote') {
+                await addProfileItem(currentItem)
+              } else if (currentItem?.type === 'plugin' && currentItem.pluginId) {
+                await updatePluginProfile(currentItem.pluginId, true)
+              }
+              setUpdating(false)
+            }}
+          >
+            <IoMdRefresh className={`text-lg ${updating ? 'animate-spin' : ''}`} />
+          </Button>
+        </>
       }
     >
       {openInfoImport && (
@@ -534,53 +550,27 @@ const Profiles: React.FC = () => {
         </div>
         <Divider />
       </div>
-      <div className="px-2">
-        <div className="flex items-center justify-between mt-2 mb-2">
-          <span className="font-bold">{t('plugins.title')}</span>
-          <div className="flex items-center gap-3">
-            <Tooltip content={t('plugins.useProxyWarning')} placement="bottom">
-              <Checkbox
-                size="sm"
-                isSelected={pluginUseProxy}
-                onValueChange={(v) => patchAppConfig({ pluginUseProxy: v })}
-              >
-                {t('plugins.useProxy')}
-              </Checkbox>
-            </Tooltip>
-            <Button
-              size="sm"
-              color="primary"
-              onPress={() => {
-                setPluginDropFile(null)
-                setPluginFileData(null)
-                setShowPluginImport(true)
-              }}
-            >
-              {t('plugins.import')}
-            </Button>
-          </div>
+
+      {showPluginImport && (
+        <PluginInstallModal
+          key={pluginDropSeq}
+          initialFile={pluginDropFile ?? undefined}
+          initialData={pluginFileData ?? undefined}
+          onClose={() => {
+            setShowPluginImport(false)
+            setPluginDropFile(null)
+            setPluginFileData(null)
+            mutatePluginConfig()
+          }}
+        />
+      )}
+      {(pluginConfig?.items?.length ?? 0) > 0 && (
+        <div className="px-2 mt-2 mb-3 grid grid-cols-1 gap-2">
+          {pluginConfig?.items?.map((p) => (
+            <PluginItem key={p.id} item={p} onChanged={mutatePluginConfig} />
+          ))}
         </div>
-        {(pluginConfig?.items?.length ?? 0) > 0 && (
-          <div className="grid grid-cols-1 gap-2 mb-3">
-            {pluginConfig?.items?.map((p) => (
-              <PluginItem key={p.id} item={p} onChanged={mutatePluginConfig} />
-            ))}
-          </div>
-        )}
-        {showPluginImport && (
-          <PluginInstallModal
-            key={pluginDropSeq}
-            initialFile={pluginDropFile ?? undefined}
-            initialData={pluginFileData ?? undefined}
-            onClose={() => {
-              setShowPluginImport(false)
-              setPluginDropFile(null)
-              setPluginFileData(null)
-              mutatePluginConfig()
-            }}
-          />
-        )}
-      </div>
+      )}
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
         <div
           className={`${fileOver ? 'blur-sm' : ''} grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2 m-2`}

--- a/src/renderer/src/utils/ipc.ts
+++ b/src/renderer/src/utils/ipc.ts
@@ -164,6 +164,7 @@ interface IpcApi {
   loginPlugin: (id: string) => Promise<void>
   removePlugin: (id: string) => Promise<void>
   updatePluginProfile: (id: string, force?: boolean) => Promise<void>
+  patchPluginItem: (id: string, patch: Partial<IPluginItem>) => Promise<void>
   // Misc
   getGistUrl: () => Promise<string>
   generateGistAgeKeyPair: () => Promise<{ secretKey: string; recipient: string }>
@@ -329,6 +330,7 @@ export const {
   loginPlugin,
   removePlugin,
   updatePluginProfile,
+  patchPluginItem,
   // Misc
   getGistUrl,
   generateGistAgeKeyPair,

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -648,6 +648,7 @@ interface IPluginItem {
   status: IPluginStatus
   interval?: number
   autoUpdate?: boolean
+  useProxy?: boolean // 插件请求经由代理开关（可选，覆盖全局配置）
   created: number
   updated: number
   lastUpdateErrorType?: 'auth' | 'transient'


### PR DESCRIPTION
## 概述

本 PR 对机场插件界面进行了交互重构与功能增强：
1. **界面与交互重构**：将机场插件导入入口收纳至配置页面 (Profiles) 顶栏，优化界面空间利用率与视觉连贯性。
2. **独立代理控制**：支持按单个插件粒度控制代理开关（Per-Plugin Proxy Settings），取代以往全局代理控制。
3. **性能提升**：优化渲染进程中读取与解析 `.cpx` 插件文件的 Base64 编码逻辑，解决大文件卡顿与潜在栈溢出问题。

---

## 主要变动

### 界面与交互 (UI & UX)
- **Profiles 顶栏新增插件入口**：在订阅配置页面的 Header 增加拼图图标按钮，指示插件功能，用于打开插件安装弹窗
- **单插件独立代理控制**：每个插件卡片 (`PluginItem`) 增加独立的代理开关 Checkbox，支持独立启用/禁用代理请求
- **安装弹窗视觉与交互统一**：
  - `PluginInstallModal` 模态框补齐 `backdrop="blur"` 与 `classNames={{ backdrop: 'top-[48px]' }}`，实现全局一致的高斯模糊背景与 TitleBar 视口避让。
  - Modal Footer 支持在安装前预设/查看代理开关，新安装的插件默认继承当前全局代理设置。

### 核心与性能 (Core & Performance)
- **大文件 Base64 转换性能优化**：重构 `abToBase64` 函数，优先使用 Node.js Native `Buffer`（若可用），并为 Web 退路增加 `32KB` 分块处理，避免大文件（如数兆字节 `.cpx`）引起渲染进程 GC 卡顿或 `Maximum call stack size exceeded` 报错。
- **数据与 IPC 管道补充**：
  - 类型定义扩展：`IPluginItem` 增加 `useProxy?: boolean` 字段。
  - 新增 `patchPluginItem` IPC 通道，支持细粒度的插件属性局部更新与渲染进程自动同步。
  - 主进程网络配置 `netOpts(record)` 优先读取插件自身的 `useProxy` 设置，回退到全局配置。

---

## 效果截图 / 演示 (Screenshots)

* **顶栏插件入口与插件列表界面**
<img width="700" alt="image" src="https://github.com/user-attachments/assets/4366f091-4eb0-4b36-a705-3f739f58b439" />


* **插件安装 Modal 弹窗**

 _先前_

<img width="700" alt="image" src="https://github.com/user-attachments/assets/749900f5-4dc6-4524-8392-ceb29c186471" />

_现在_

<img width="700" alt="image" src="https://github.com/user-attachments/assets/8349d52e-1b58-42db-af39-cef439fae695" />

<img width="700" alt="image" src="https://github.com/user-attachments/assets/f38889c1-296d-46af-8bb5-ccbf2d143610" />

* **单插件独立代理设置**
<img width="700" alt="image" src="https://github.com/user-attachments/assets/6e754d3d-3bf0-4b55-a0f2-132f343e82ab" />

---

## 验证与测试 (Verification & Testing)

- [x] **单元测试**：运行 `pnpm test` 通过全部 19 个测试套件，共 174 项单元测试
- [x] **老数据兼容性**：测试历史插件配置加载，无 `useProxy` 字段的插件平滑降级为全局 `pluginUseProxy` 设置，运行正常
- [x] **大文件导入验证**：测试拖拽与选取较大 `.cpx` 文件导入，预览与安装流程流畅无卡顿

---

## 兼容性与破坏性变更 (Breaking Changes)

- **无破坏性变更**：配置结构完全向下兼容。

---
## AI 辅助声明 (AI Assistance)

本 PR 的代码审阅、交互与性能重构、模态遮罩与 UI 防滑溢出修复及单元测试验证，使用了 **Antigravity (Gemini 3.1 Pro/Gemini 3.6 Flash)** 辅助完成。