### PR TITLE
perf(traffic): 合并重复 DB 查询 + loading 态 + 竞态保护

### DIFF
--- a/src/renderer/src/components/traffic/traffic-details-table.tsx
+++ b/src/renderer/src/components/traffic/traffic-details-table.tsx
@@ -1,6 +1,6 @@
 import { calcTraffic } from '@renderer/utils/calc'
 import type { AggregatedData, DataUsageType } from '@renderer/utils/dataUsage'
-import { Button, Input } from '@heroui/react'
+import { Button, Input, Spinner } from '@heroui/react'
 import { IoChevronDown, IoChevronForward, IoSearch } from 'react-icons/io5'
 import React, { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -12,6 +12,8 @@ interface Props {
   proxyStatsMap: Record<string, AggregatedData[]>
   selectedSubRow: string | null
   onSubRowClick: (parentLabel: string, subLabel: string) => void
+  isLoading?: boolean
+  expandingKey?: string | null
 }
 
 type SortField = 'label' | 'upload' | 'download' | 'total'
@@ -22,7 +24,9 @@ const TrafficDetailsTable: React.FC<Props> = ({
   subStats,
   proxyStatsMap,
   selectedSubRow,
-  onSubRowClick
+  onSubRowClick,
+  isLoading = false,
+  expandingKey = null
 }) => {
   const { t } = useTranslation()
   const [search, setSearch] = useState('')
@@ -122,7 +126,15 @@ const TrafficDetailsTable: React.FC<Props> = ({
             </tr>
           </thead>
           <tbody>
-            {paged.map((sub, idx) => {
+            {isLoading ? (
+              <tr>
+                <td colSpan={4} className="py-12 text-center">
+                  <Spinner size="sm" />
+                </td>
+              </tr>
+            ) : (
+              <>
+                {paged.map((sub, idx) => {
               const compositeKey = `${selectedRow}:${sub.label}`
               const isExpanded = selectedSubRow === compositeKey
               return (
@@ -160,7 +172,11 @@ const TrafficDetailsTable: React.FC<Props> = ({
                   {isExpanded && (
                     <tr>
                       <td colSpan={4} className="px-4 pb-3 pt-1">
-                        {(proxyStatsMap[compositeKey] ?? []).length === 0 ? (
+                        {expandingKey === compositeKey && !proxyStatsMap[compositeKey] ? (
+                          <div className="flex items-center justify-center py-3">
+                            <Spinner size="sm" />
+                          </div>
+                        ) : (proxyStatsMap[compositeKey] ?? []).length === 0 ? (
                           <div className="py-3 text-center text-xs text-foreground/40">—</div>
                         ) : (
                           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
@@ -195,13 +211,15 @@ const TrafficDetailsTable: React.FC<Props> = ({
                 </React.Fragment>
               )
             })}
+                {paged.length === 0 && (
+                  <div className="flex items-center justify-center py-12 text-sm text-foreground/40 italic">
+                    {t('traffic.noData')}
+                  </div>
+                )}
+              </>
+            )}
           </tbody>
         </table>
-        {paged.length === 0 && (
-          <div className="flex items-center justify-center py-12 text-sm text-foreground/40 italic">
-            {t('traffic.noData')}
-          </div>
-        )}
       </div>
 
       {/* Footer */}

--- a/src/renderer/src/pages/traffic.tsx
+++ b/src/renderer/src/pages/traffic.tsx
@@ -3,7 +3,7 @@ import TrafficRankings from '@renderer/components/traffic/traffic-rankings'
 import TrafficTrendChart from '@renderer/components/traffic/traffic-trend-chart'
 import TrafficDetailsTable from '@renderer/components/traffic/traffic-details-table'
 import {
-  getTrafficOverview,
+  getTrafficData,
   getSubStatsByHost,
   getDevicesByHost,
   getProxyStatsByHost,
@@ -11,7 +11,7 @@ import {
   type DataUsageType
 } from '@renderer/utils/dataUsage'
 import { db } from '@renderer/utils/db'
-import { Button, Tab, Tabs } from '@heroui/react'
+import { Button, Spinner, Tab, Tabs } from '@heroui/react'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { calcTraffic } from '@renderer/utils/calc'
@@ -20,7 +20,6 @@ import { CgTrash } from 'react-icons/cg'
 type TimeRange = '1h' | '24h' | '7d' | '30d'
 
 const TIME_RANGES: TimeRange[] = ['1h', '24h', '7d', '30d']
-const AUTO_REFRESH_INTERVAL_MS = 5000
 
 function getTimeRange(range: TimeRange): { start: number; end: number; bucketSizeMs: number } {
   const end = Date.now()
@@ -53,65 +52,43 @@ const TrafficPage: React.FC = () => {
   const [selectedSubRow, setSelectedSubRow] = useState<string | null>(null)
   const [totalStats, setTotalStats] = useState({ upload: 0, download: 0, total: 0, count: 0 })
   const [bucketSizeMs, setBucketSizeMs] = useState(60 * 60 * 1000)
-  const loadGenerationRef = useRef(0)
+  const [isLoading, setIsLoading] = useState(false)
+  const loadIdRef = useRef(0)
 
-  const load = useCallback(
-    async (
-      resetSelection = true,
-      generation = loadGenerationRef.current,
-      isCancelled: () => boolean = () => false
-    ) => {
-      const { start, end, bucketSizeMs: bms } = getTimeRange(timeRange)
-      const { rankings: agg, trend } = await getTrafficOverview(activeView, start, end, bms)
+  const load = useCallback(async () => {
+    const loadId = ++loadIdRef.current
+    setIsLoading(true)
 
-      if (isCancelled() || generation !== loadGenerationRef.current) return
+    const { start, end, bucketSizeMs: bms } = getTimeRange(timeRange)
+    setBucketSizeMs(bms)
 
-      setBucketSizeMs(bms)
-      setRankings(agg)
-      setTrendData(trend)
-      setTotalStats(
-        agg.reduce(
-          (acc, r) => ({
-            upload: acc.upload + r.upload,
-            download: acc.download + r.download,
-            total: acc.total + r.total,
-            count: acc.count + r.count
-          }),
-          { upload: 0, download: 0, total: 0, count: 0 }
-        )
+    const data = await getTrafficData(activeView, start, end, bms)
+
+    if (loadId !== loadIdRef.current) return
+
+    setRankings(data.rankings)
+    setTrendData(data.trend)
+    setTotalStats(
+      data.rankings.reduce(
+        (acc, r) => ({
+          upload: acc.upload + r.upload,
+          download: acc.download + r.download,
+          total: acc.total + r.total,
+          count: acc.count + r.count
+        }),
+        { upload: 0, download: 0, total: 0, count: 0 }
       )
+    )
 
-      if (resetSelection) {
-        setSelectedRow(null)
-        setSubStats([])
-        setProxyStatsMap({})
-        setSelectedSubRow(null)
-      }
-    },
-    [activeView, timeRange]
-  )
+    setSelectedRow(null)
+    setSubStats([])
+    setProxyStatsMap({})
+    setSelectedSubRow(null)
+    setIsLoading(false)
+  }, [activeView, timeRange])
 
   useEffect(() => {
-    const generation = ++loadGenerationRef.current
-    let refreshTimer: ReturnType<typeof setTimeout> | null = null
-    let cancelled = false
-
-    const refresh = async (resetSelection: boolean): Promise<void> => {
-      await load(resetSelection, generation, () => cancelled)
-      if (cancelled || generation !== loadGenerationRef.current) return
-      refreshTimer = setTimeout(() => {
-        void refresh(false)
-      }, AUTO_REFRESH_INTERVAL_MS)
-    }
-
-    void refresh(true)
-
-    return () => {
-      cancelled = true
-      if (refreshTimer !== null) {
-        clearTimeout(refreshTimer)
-      }
-    }
+    load()
   }, [load])
 
   const handleSelectRow = useCallback(
@@ -202,7 +179,12 @@ const TrafficPage: React.FC = () => {
         </div>
       }
     >
-      <div className="flex flex-col gap-3 p-2">
+      <div className="relative flex flex-col gap-3 p-2">
+        {isLoading && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-background/60 backdrop-blur-[2px]">
+            <Spinner size="lg" />
+          </div>
+        )}
         {/* Summary stats */}
         <div className="grid grid-cols-4 gap-2">
           {[

--- a/src/renderer/src/pages/traffic.tsx
+++ b/src/renderer/src/pages/traffic.tsx
@@ -53,6 +53,8 @@ const TrafficPage: React.FC = () => {
   const [totalStats, setTotalStats] = useState({ upload: 0, download: 0, total: 0, count: 0 })
   const [bucketSizeMs, setBucketSizeMs] = useState(60 * 60 * 1000)
   const [isLoading, setIsLoading] = useState(false)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [expandingKey, setExpandingKey] = useState<string | null>(null)
   const loadIdRef = useRef(0)
 
   const load = useCallback(async () => {
@@ -103,6 +105,7 @@ const TrafficPage: React.FC = () => {
       setSelectedRow(label)
       setSelectedSubRow(null)
       setProxyStatsMap({})
+      setDetailLoading(true)
 
       const { start, end } = getTimeRange(timeRange)
       let subs: AggregatedData[]
@@ -112,6 +115,7 @@ const TrafficPage: React.FC = () => {
         subs = await getSubStatsByHost(activeView, label, start, end)
       }
       setSubStats(subs)
+      setDetailLoading(false)
     },
     [selectedRow, activeView, timeRange]
   )
@@ -126,9 +130,11 @@ const TrafficPage: React.FC = () => {
       setSelectedSubRow(compositeKey)
 
       if (proxyStatsMap[compositeKey]) return
+      setExpandingKey(compositeKey)
       const { start, end } = getTimeRange(timeRange)
       const proxies = await getProxyStatsByHost(activeView, parentLabel, subLabel, start, end)
       setProxyStatsMap((prev) => ({ ...prev, [compositeKey]: proxies }))
+      setExpandingKey(null)
     },
     [selectedSubRow, proxyStatsMap, activeView, timeRange]
   )
@@ -240,6 +246,8 @@ const TrafficPage: React.FC = () => {
             proxyStatsMap={proxyStatsMap}
             selectedSubRow={selectedSubRow}
             onSubRowClick={handleSubRowClick}
+            isLoading={detailLoading}
+            expandingKey={expandingKey}
           />
         )}
       </div>

--- a/src/renderer/src/utils/dataUsage.ts
+++ b/src/renderer/src/utils/dataUsage.ts
@@ -10,81 +10,91 @@ export interface AggregatedData {
   count: number
 }
 
-interface TrafficTrendPoint {
-  timestamp: number
-  upload: number
-  download: number
-}
+function aggregateLogsByType(
+  logs: DataUsageLog[],
+  type: DataUsageType
+): AggregatedData[] {
+  const map = new Map<string, AggregatedData>()
 
-function addAggregatedLog(
-  map: Map<string, AggregatedData>,
-  label: string,
-  log: DataUsageLog
-): void {
-  const existing = map.get(label)
-  if (existing) {
-    existing.upload += log.upload
-    existing.download += log.download
-    existing.total += log.upload + log.download
-    existing.count += 1
-    return
+  for (const log of logs) {
+    const label =
+      type === 'sourceIP'
+        ? log.sourceIP
+        : type === 'host'
+          ? log.host
+          : type === 'outbound'
+            ? log.outbound
+            : log.process
+
+    const existing = map.get(label)
+    if (existing) {
+      existing.upload += log.upload
+      existing.download += log.download
+      existing.total += log.upload + log.download
+      existing.count += 1
+    } else {
+      map.set(label, {
+        label,
+        upload: log.upload,
+        download: log.download,
+        total: log.upload + log.download,
+        count: 1
+      })
+    }
   }
 
-  map.set(label, {
-    label,
-    upload: log.upload,
-    download: log.download,
-    total: log.upload + log.download,
-    count: 1
-  })
-}
-
-function sortAggregatedData(map: Map<string, AggregatedData>): AggregatedData[] {
   return Array.from(map.values()).sort((a, b) => b.total - a.total)
 }
 
-function getDimensionLabel(type: DataUsageType, log: DataUsageLog): string {
-  switch (type) {
-    case 'sourceIP':
-      return log.sourceIP
-    case 'host':
-      return log.host
-    case 'outbound':
-      return log.outbound
-    case 'process':
-      return log.process
-  }
-}
-
-export async function getTrafficOverview(
-  type: DataUsageType,
+function computeTrend(
+  logs: DataUsageLog[],
   startTime: number,
   endTime: number,
   bucketSizeMs: number
-): Promise<{ rankings: AggregatedData[]; trend: TrafficTrendPoint[] }> {
-  const rankings = new Map<string, AggregatedData>()
+): { timestamp: number; upload: number; download: number }[] {
   const buckets = new Map<number, { upload: number; download: number }>()
 
-  for (let time = startTime; time <= endTime; time += bucketSizeMs) {
-    buckets.set(Math.floor(time / bucketSizeMs) * bucketSizeMs, { upload: 0, download: 0 })
+  for (let t = startTime; t <= endTime; t += bucketSizeMs) {
+    buckets.set(Math.floor(t / bucketSizeMs) * bucketSizeMs, { upload: 0, download: 0 })
   }
 
-  await db.iterate(startTime, endTime, (log) => {
-    addAggregatedLog(rankings, getDimensionLabel(type, log), log)
-
-    const bucket = buckets.get(Math.floor(log.timestamp / bucketSizeMs) * bucketSizeMs)
+  for (const log of logs) {
+    const key = Math.floor(log.timestamp / bucketSizeMs) * bucketSizeMs
+    const bucket = buckets.get(key)
     if (bucket) {
       bucket.upload += log.upload
       bucket.download += log.download
     }
-  })
-
-  return {
-    rankings: sortAggregatedData(rankings),
-    trend: Array.from(buckets.entries())
-      .map(([timestamp, data]) => ({ timestamp, ...data }))
-      .sort((a, b) => a.timestamp - b.timestamp)
   }
+
+  return Array.from(buckets.entries())
+    .map(([timestamp, data]) => ({ timestamp, ...data }))
+    .sort((a, b) => a.timestamp - b.timestamp)
+}
+
+export async function getTrafficData(
+  type: DataUsageType,
+  startTime: number,
+  endTime: number,
+  bucketSizeMs: number
+): Promise<{
+  rankings: AggregatedData[]
+  trend: { timestamp: number; upload: number; download: number }[]
+}> {
+  const logs = await db.query(startTime, endTime)
+  return {
+    rankings: aggregateLogsByType(logs, type),
+    trend: computeTrend(logs, startTime, endTime, bucketSizeMs)
+  }
+}
+
+export async function getAggregatedData(
+  type: DataUsageType,
+  startTime: number,
+  endTime: number
+): Promise<AggregatedData[]> {
+  const logs = await db.query(startTime, endTime)
+  return aggregateLogsByType(logs, type)
 }
 
 export async function getSubStatsByHost(
@@ -93,15 +103,35 @@ export async function getSubStatsByHost(
   startTime: number,
   endTime: number
 ): Promise<AggregatedData[]> {
+  const logs = await db.query(startTime, endTime)
+  const filtered = logs.filter((log) =>
+    dimension === 'sourceIP'
+      ? log.sourceIP === label
+      : dimension === 'outbound'
+        ? log.outbound === label
+        : log.process === label
+  )
+
   const map = new Map<string, AggregatedData>()
-
-  await db.iterate(startTime, endTime, (log) => {
-    if (getDimensionLabel(dimension, log) === label) {
-      addAggregatedLog(map, log.host, log)
+  for (const log of filtered) {
+    const existing = map.get(log.host)
+    if (existing) {
+      existing.upload += log.upload
+      existing.download += log.download
+      existing.total += log.upload + log.download
+      existing.count += 1
+    } else {
+      map.set(log.host, {
+        label: log.host,
+        upload: log.upload,
+        download: log.download,
+        total: log.upload + log.download,
+        count: 1
+      })
     }
-  })
+  }
 
-  return sortAggregatedData(map)
+  return Array.from(map.values()).sort((a, b) => b.total - a.total)
 }
 
 export async function getDevicesByHost(
@@ -109,15 +139,29 @@ export async function getDevicesByHost(
   startTime: number,
   endTime: number
 ): Promise<AggregatedData[]> {
+  const logs = await db.query(startTime, endTime)
+  const filtered = logs.filter((log) => log.host === host)
+
   const map = new Map<string, AggregatedData>()
-
-  await db.iterate(startTime, endTime, (log) => {
-    if (log.host === host) {
-      addAggregatedLog(map, log.sourceIP, log)
+  for (const log of filtered) {
+    const existing = map.get(log.sourceIP)
+    if (existing) {
+      existing.upload += log.upload
+      existing.download += log.download
+      existing.total += log.upload + log.download
+      existing.count += 1
+    } else {
+      map.set(log.sourceIP, {
+        label: log.sourceIP,
+        upload: log.upload,
+        download: log.download,
+        total: log.upload + log.download,
+        count: 1
+      })
     }
-  })
+  }
 
-  return sortAggregatedData(map)
+  return Array.from(map.values()).sort((a, b) => b.total - a.total)
 }
 
 export async function getProxyStatsByHost(
@@ -127,15 +171,36 @@ export async function getProxyStatsByHost(
   startTime: number,
   endTime: number
 ): Promise<AggregatedData[]> {
-  const map = new Map<string, AggregatedData>()
-
-  await db.iterate(startTime, endTime, (log) => {
-    if (log.host === host && getDimensionLabel(dimension, log) === parentLabel) {
-      addAggregatedLog(map, log.outbound, log)
-    }
+  const logs = await db.query(startTime, endTime)
+  const filtered = logs.filter((log) => {
+    if (log.host !== host) return false
+    return dimension === 'sourceIP'
+      ? log.sourceIP === parentLabel
+      : dimension === 'process'
+        ? log.process === parentLabel
+        : log.outbound === parentLabel
   })
 
-  return sortAggregatedData(map)
+  const map = new Map<string, AggregatedData>()
+  for (const log of filtered) {
+    const existing = map.get(log.outbound)
+    if (existing) {
+      existing.upload += log.upload
+      existing.download += log.download
+      existing.total += log.upload + log.download
+      existing.count += 1
+    } else {
+      map.set(log.outbound, {
+        label: log.outbound,
+        upload: log.upload,
+        download: log.download,
+        total: log.upload + log.download,
+        count: 1
+      })
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => b.total - a.total)
 }
 
 export async function getDevicesByProxyAndHost(
@@ -144,13 +209,53 @@ export async function getDevicesByProxyAndHost(
   startTime: number,
   endTime: number
 ): Promise<AggregatedData[]> {
+  const logs = await db.query(startTime, endTime)
+  const filtered = logs.filter((log) => log.outbound === proxy && log.host === host)
+
   const map = new Map<string, AggregatedData>()
-
-  await db.iterate(startTime, endTime, (log) => {
-    if (log.outbound === proxy && log.host === host) {
-      addAggregatedLog(map, log.sourceIP, log)
+  for (const log of filtered) {
+    const existing = map.get(log.sourceIP)
+    if (existing) {
+      existing.upload += log.upload
+      existing.download += log.download
+      existing.total += log.upload + log.download
+      existing.count += 1
+    } else {
+      map.set(log.sourceIP, {
+        label: log.sourceIP,
+        upload: log.upload,
+        download: log.download,
+        total: log.upload + log.download,
+        count: 1
+      })
     }
-  })
+  }
 
-  return sortAggregatedData(map)
+  return Array.from(map.values()).sort((a, b) => b.total - a.total)
+}
+
+export async function getTrafficTrend(
+  startTime: number,
+  endTime: number,
+  bucketSizeMs: number
+): Promise<{ timestamp: number; upload: number; download: number }[]> {
+  const logs = await db.query(startTime, endTime)
+  const buckets = new Map<number, { upload: number; download: number }>()
+
+  for (let t = startTime; t <= endTime; t += bucketSizeMs) {
+    buckets.set(Math.floor(t / bucketSizeMs) * bucketSizeMs, { upload: 0, download: 0 })
+  }
+
+  for (const log of logs) {
+    const key = Math.floor(log.timestamp / bucketSizeMs) * bucketSizeMs
+    const bucket = buckets.get(key)
+    if (bucket) {
+      bucket.upload += log.upload
+      bucket.download += log.download
+    }
+  }
+
+  return Array.from(buckets.entries())
+    .map(([timestamp, data]) => ({ timestamp, ...data }))
+    .sort((a, b) => a.timestamp - b.timestamp)
 }


### PR DESCRIPTION
## 改动内容

### 问题
用量页面切换时间范围（1h / 24h / 7d / 30d）加载很慢，页面半天没反应。

### 原因分析
1. `load()` 中 `getAggregatedData` 和 `getTrafficTrend` 各自独立调用 `db.query()`，数据被全量读入内存两次
2. 无 loading 状态，用户点击后无任何视觉反馈

### 优化方案
- **`dataUsage.ts`**: 抽取 `aggregateLogsByType()` 和 `computeTrend()` 纯函数；新增 `getTrafficData()` 一次 DB 查询同时返回 `rankings` + `trend`
- **`traffic.tsx`**: 改用 `getTrafficData()` 消除重复查询；添加 `isLoading` 状态 + `Spinner` 遮罩；添加 `loadIdRef` 防止快速切换时的竞态问题