### PR TITLE
fix: restore macOS connection app icons

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -15,6 +15,8 @@ files:
   - '!{.eslintignore,.eslintrc.cjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}'
   - '!{.env,.env.*,.npmrc,pnpm-lock.yaml}'
   - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
+asarUnpack:
+  - 'node_modules/file-icon/file-icon'
 extraResources:
   - from: './extra/'
     to: ''

--- a/src/main/utils/icon.test.ts
+++ b/src/main/utils/icon.test.ts
@@ -1,0 +1,113 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let packaged = false
+const execFile = vi.fn()
+const fileIconToBuffer = vi.fn()
+
+vi.mock('electron', () => ({
+  app: {
+    get isPackaged() {
+      return packaged
+    },
+    getPath: vi.fn(() => '')
+  }
+}))
+
+vi.mock('child_process', () => ({
+  exec: vi.fn(),
+  execFile
+}))
+
+vi.mock('file-icon', () => ({ fileIconToBuffer }))
+vi.mock('file-icon-info', () => ({ getIcon: vi.fn() }))
+vi.mock('../config', () => ({ getControledMihomoConfig: vi.fn() }))
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+const resourcesPathDescriptor = Object.getOwnPropertyDescriptor(process, 'resourcesPath')
+let tempDir: string
+let outerApp: string
+let helperExecutable: string
+
+beforeEach(() => {
+  packaged = false
+  execFile.mockReset()
+  fileIconToBuffer.mockReset()
+  vi.resetModules()
+
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+  Object.defineProperty(process, 'resourcesPath', {
+    configurable: true,
+    value: '/tmp/clash-party-resources'
+  })
+
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clash-party-icon-'))
+  outerApp = path.join(tempDir, 'Browser.app')
+  helperExecutable = path.join(
+    outerApp,
+    'Contents',
+    'Frameworks',
+    'Browser Helper.app',
+    'Contents',
+    'MacOS',
+    'Browser Helper'
+  )
+  fs.mkdirSync(path.join(outerApp, 'Contents', 'Resources'), { recursive: true })
+  fs.mkdirSync(path.dirname(helperExecutable), { recursive: true })
+  fs.writeFileSync(path.join(outerApp, 'Contents', 'Resources', 'Browser.icns'), '')
+})
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true })
+  if (platformDescriptor) {
+    Object.defineProperty(process, 'platform', platformDescriptor)
+  }
+  if (resourcesPathDescriptor) {
+    Object.defineProperty(process, 'resourcesPath', resourcesPathDescriptor)
+  } else {
+    delete process.resourcesPath
+  }
+  vi.restoreAllMocks()
+})
+
+describe('getIconDataURL on macOS', () => {
+  it('executes the unpacked file-icon helper in packaged builds', async () => {
+    packaged = true
+    execFile.mockImplementation((_file, _args, _options, callback) => {
+      callback(null, Buffer.from('packaged-icon'), Buffer.alloc(0))
+    })
+
+    const { getIconDataURL } = await import('./icon')
+    const result = await getIconDataURL(helperExecutable)
+
+    expect(execFile).toHaveBeenCalledWith(
+      path.join(
+        '/tmp/clash-party-resources',
+        'app.asar.unpacked',
+        'node_modules',
+        'file-icon',
+        'file-icon'
+      ),
+      [JSON.stringify([{ appOrPID: outerApp, size: 512 }])],
+      { encoding: null, maxBuffer: 100 * 1024 * 1024 },
+      expect.any(Function)
+    )
+    expect(fileIconToBuffer).not.toHaveBeenCalled()
+    expect(result).toBe(`data:image/png;base64,${Buffer.from('packaged-icon').toString('base64')}`)
+  })
+
+  it('uses the file-icon module directly during development', async () => {
+    fileIconToBuffer.mockResolvedValue(Buffer.from('development-icon'))
+
+    const { getIconDataURL } = await import('./icon')
+    const result = await getIconDataURL(helperExecutable)
+
+    expect(fileIconToBuffer).toHaveBeenCalledWith(outerApp, { size: 512 })
+    expect(execFile).not.toHaveBeenCalled()
+    expect(result).toBe(
+      `data:image/png;base64,${Buffer.from('development-icon').toString('base64')}`
+    )
+  })
+})

--- a/src/main/utils/icon.ts
+++ b/src/main/utils/icon.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process'
+import { exec, execFile } from 'child_process'
 import fs, { existsSync } from 'fs'
 import os from 'os'
 import path from 'path'
@@ -80,6 +80,36 @@ export function findBestAppPath(appPath: string): string | null {
     }
   }
   return appPaths[0]
+}
+
+async function getMacOSIconBuffer(appPath: string): Promise<Buffer> {
+  if (!app.isPackaged) {
+    const { fileIconToBuffer } = await import('file-icon')
+    return Buffer.from(await fileIconToBuffer(appPath, { size: 512 }))
+  }
+
+  const fileIconPath = path.join(
+    process.resourcesPath,
+    'app.asar.unpacked',
+    'node_modules',
+    'file-icon',
+    'file-icon'
+  )
+
+  return new Promise((resolve, reject) => {
+    execFile(
+      fileIconPath,
+      [JSON.stringify([{ appOrPID: appPath, size: 512 }])],
+      { encoding: null, maxBuffer: 100 * 1024 * 1024 },
+      (error, stdout) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolve(stdout)
+      }
+    )
+  })
 }
 
 async function findDesktopFile(appPath: string): Promise<string | null> {
@@ -184,12 +214,11 @@ export async function getIconDataURL(appPath: string): Promise<string> {
     if (!appPath.includes('.app') && !appPath.includes('.xpc')) {
       return darwinDefaultIcon
     }
-    const { fileIconToBuffer } = await import('file-icon')
     const targetPath = findBestAppPath(appPath)
     if (!targetPath) {
       return darwinDefaultIcon
     }
-    const iconBuffer = await fileIconToBuffer(targetPath, { size: 512 })
+    const iconBuffer = await getMacOSIconBuffer(targetPath)
     const base64Icon = Buffer.from(iconBuffer).toString('base64')
     return `data:image/png;base64,${base64Icon}`
   }


### PR DESCRIPTION
## Summary

- execute the packaged macOS `file-icon` helper from `app.asar.unpacked`
- keep the existing `fileIconToBuffer` path for development
- explicitly unpack the helper and cover both paths with regression tests

## Problem

In a packaged build, `file-icon` resolves its native helper relative to its JavaScript module inside `app.asar`:

```
.../Resources/app.asar/node_modules/file-icon/file-icon
```

Because `app.asar` is a file, spawning that path fails with `ENOTDIR`. The helper itself is available under `app.asar.unpacked`, so this change invokes that binary directly in packaged builds using the same CLI payload and buffer limits as `file-icon`.

## Verification

- `vitest run`
- Prettier and ESLint checks
- main and renderer TypeScript checks
- `electron-vite build`
- unsigned macOS directory build with `electron-builder --mac --dir`
- packaged helper returned a 512x512 PNG for Vivaldi
