### PR TITLE
fix: notify the renderer after a scheduled subscription update

### DIFF
--- a/src/main/core/profileUpdater.ts
+++ b/src/main/core/profileUpdater.ts
@@ -29,6 +29,10 @@ async function updateProfile(id: string): Promise<void> {
     const item = await getProfileItem(id)
     if (item && item.type === 'remote') {
       await addProfileItem(item)
+      // 后台定时更新完成后主动通知渲染层，否则订阅列表的更新时间/流量要等窗口重新聚焦才刷新（#1570）
+      // 动态 import 避免与 window.ts 形成静态循环依赖
+      const { mainWindow } = await import('../window')
+      mainWindow?.webContents.send('profileConfigUpdated')
     } else if (item && item.type === 'plugin' && item.pluginId) {
       const { updatePluginProfile } = await import('../resolve/plugin')
       await updatePluginProfile(item.pluginId)


### PR DESCRIPTION
fix: notify the renderer after a scheduled subscription update

The scheduled updater calls addProfileItem, which never sends
profileConfigUpdated. The subscription list revalidates on that event, so
the "updated N minutes ago" line and the traffic figures stayed stale
until the window regained focus - which reads exactly like the interval
not working. The plugin update path already notifies; only the remote one
did not.

Refs #1570

This addresses the stale UI half of the report. A scheduled update of the
profile that is currently active still writes the new YAML without
reloading it into the running core, because changeCurrentProfile returns
early when the id is unchanged; that part is left for a separate change.

---
Verified on Windows 11: `pnpm run review` (prettier + eslint + tsc) and `pnpm run test` (176 tests) pass, and `electron-vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
