### PR TITLE
fix: restore the real tray icon when the traffic display is turned off

### DIFF
--- a/src/renderer/src/components/sider/conn-card.tsx
+++ b/src/renderer/src/components/sider/conn-card.tsx
@@ -8,6 +8,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { IoLink } from 'react-icons/io5'
 import { useAppConfig } from '@renderer/hooks/use-app-config'
 import { platform } from '@renderer/utils/init'
+import { updateTrayIcon } from '@renderer/utils/ipc'
 import { Line } from 'react-chartjs-2'
 import {
   Chart as ChartJS,
@@ -168,9 +169,12 @@ const ConnCard: React.FC<Props> = (props) => {
       window.electron.ipcRenderer.send('trayIconUpdate', png, true)
       hasShowTrafficRef.current = true
     } else if (hasShowTrafficRef.current) {
-      // 关闭：恢复原始图标
+      // 关闭：先让主进程退出流量图标模式（enabled=false 会清掉它的提前 return），
+      // 再请主进程用 resources 里的真实图标重绘一次；只发这条 IPC 的话托盘会一直停在
+      // 渲染进程发过去的这张兜底图上，状态色丢失且必须重启才恢复
       window.electron.ipcRenderer.send('trayIconUpdate', trayIconBase64, false)
       hasShowTrafficRef.current = false
+      updateTrayIcon().catch(() => {})
     }
   }, [showTraffic])
 


### PR DESCRIPTION
fix: restore the real tray icon when the traffic display is turned off

Turning the traffic display off sent trayIconUpdate with enabled=false,
but the handler ignores that flag and always applies the supplied data
URL, so the tray kept showing the renderer-composed image until the app
was restarted. Ask the main process to redraw from its own resources
afterwards.

Refs #1080

This covers the "does not recover" half of the report. The colours being
wrong while the traffic display is on has the same root cause as #1143 -
the handler calls setTemplateImage(true) unconditionally, so macOS renders
alpha only - and needs a change in tray.ts.

---
Verified on Windows 11: `pnpm run review` (prettier + eslint + tsc) and `pnpm run test` (176 tests) pass, and `electron-vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
