### PR TITLE
fix: do not let the tunnel editor overwrite a profile it failed to read

### DIFF
--- a/src/renderer/src/components/profiles/edit-tunnels-modal.tsx
+++ b/src/renderer/src/components/profiles/edit-tunnels-modal.tsx
@@ -194,6 +194,9 @@ const EditTunnelsModal: React.FC<Props> = (props) => {
   const [newTunnel, setNewTunnel] = useState<TunnelItem>(defaultTunnel)
   const [editingIndex, setEditingIndex] = useState<number | undefined>()
   const [isLoading, setIsLoading] = useState(true)
+  // 保存会整份重写订阅文件，所以只要没成功读到原文就绝不允许保存，
+  // 否则 profile 还是初始的 {}，一保存就把用户的订阅内容清空。
+  const [loadFailed, setLoadFailed] = useState(false)
 
   const addressInvalid = useMemo(() => {
     if (!newTunnel.address.trim()) return false
@@ -210,14 +213,21 @@ const EditTunnelsModal: React.FC<Props> = (props) => {
   useEffect(() => {
     const loadContent = async (): Promise<void> => {
       setIsLoading(true)
+      setLoadFailed(false)
       try {
         const content = await getProfileStr(id)
         const parsed = yaml.load(content)
-        const nextProfile = parsed && typeof parsed === 'object' ? (parsed as ProfileYaml) : {}
+        // 解析结果不是对象时（例如订阅是 age 加密的，磁盘上存的是密文），
+        // 旧实现静默退化成 {} 且不提示，保存就会把整份订阅写没。
+        if (!parsed || typeof parsed !== 'object') {
+          throw new Error('Profile is not a YAML mapping')
+        }
+        const nextProfile = parsed as ProfileYaml
         setProfile(nextProfile)
         setTunnels(parseTunnels(nextProfile.tunnels))
         setProxyNames(collectProxyNames(nextProfile))
       } catch (e) {
+        setLoadFailed(true)
         toast.error(
           t('profiles.editTunnels.loadError') + ': ' + (e instanceof Error ? e.message : String(e))
         )
@@ -282,6 +292,9 @@ const EditTunnelsModal: React.FC<Props> = (props) => {
   }
 
   const handleSave = async (): Promise<void> => {
+    // 原文没读到就直接拒绝写回，避免用空对象覆盖订阅
+    if (isLoading || loadFailed) return
+
     try {
       const nextProfile: ProfileYaml = { ...profile }
       if (tunnels.length > 0) {
@@ -474,7 +487,12 @@ const EditTunnelsModal: React.FC<Props> = (props) => {
           <Button size="sm" variant="light" onPress={onClose}>
             {t('common.cancel')}
           </Button>
-          <Button size="sm" color="primary" onPress={handleSave}>
+          <Button
+            size="sm"
+            color="primary"
+            isDisabled={isLoading || loadFailed}
+            onPress={handleSave}
+          >
             {t('common.save')}
           </Button>
         </ModalFooter>


### PR DESCRIPTION
fix: do not let the tunnel editor overwrite a profile it failed to read

EditTunnelsModal saves by spreading the in-memory `profile` state and
writing the whole document back with setProfileStr, which replaces the
profile file outright and then hot-reloads the core. `profile` starts as
`{}` and is only filled in once the async load succeeds.

Neither failure path stops the user from saving:

  - When yaml.load throws (a subscription with a duplicated mapping key,
    for example) the catch only shows a toast. `profile` stays `{}`, so
    pressing save serialises "{}\n" over the profile and every proxy,
    proxy-group and rule is gone.

  - When the parsed value is not an object the code silently substituted
    `{}` with no toast at all. An age-encrypted profile hits this: the
    file on disk is ciphertext and getProfileStr does not decrypt, so
    yaml.load returns a string, the dialog shows "no tunnels", and saving
    destroys the encrypted profile.

The save button was also enabled while the initial load was still in
flight.

Treat a non-object parse result as an error instead of silently
substituting `{}`, record the failure, and refuse to save - both in
handleSave and by disabling the button - until the profile has actually
been read.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
Verified on Windows 11: `pnpm run review` (prettier + eslint + tsc) and `pnpm run test` (176 tests) pass, and `electron-vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
