### PR TITLE
test: make dirs.test.ts pass on Windows

### DIFF
--- a/src/main/utils/dirs.test.ts
+++ b/src/main/utils/dirs.test.ts
@@ -1,4 +1,12 @@
+import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// dirs.ts 用 path.join 拼路径，在 Windows 上会得到反斜杠分隔符。
+// 断言里不能写死 POSIX 字面量，否则整个用例只在类 Unix 平台通过。
+const APP_DATA = path.join(path.sep, 'tmp', 'app-data')
+const HOME = path.join(path.sep, 'tmp', 'home')
+const EXE_DIR = path.join(path.sep, 'tmp', 'runtime', 'Electron.app', 'Contents', 'MacOS')
+const EXE = path.join(EXE_DIR, 'Electron')
 
 let packaged = false
 let portable = false
@@ -27,7 +35,7 @@ vi.mock('fs', async (importOriginal) => {
   const original = await importOriginal<typeof import('fs')>()
   return {
     ...original,
-    existsSync: (value: string) => portable && value.endsWith('/PORTABLE')
+    existsSync: (value: string) => portable && path.basename(value) === 'PORTABLE'
   }
 })
 
@@ -38,10 +46,10 @@ beforeEach(() => {
   portable = false
   appName = 'mihomo-party'
   Object.assign(paths, {
-    appData: '/tmp/app-data',
-    userData: '/tmp/app-data/mihomo-party',
-    home: '/tmp/home',
-    exe: '/tmp/runtime/Electron.app/Contents/MacOS/Electron'
+    appData: APP_DATA,
+    userData: path.join(APP_DATA, 'mihomo-party'),
+    home: HOME,
+    exe: EXE
   })
   setPath.mockClear()
   setName.mockClear()
@@ -56,7 +64,7 @@ describe('configureAppPaths', () => {
     configureAppPaths()
 
     expect(setName).toHaveBeenCalledWith('mihomo-party-dev')
-    expect(paths.userData).toBe('/tmp/app-data/mihomo-party-dev')
+    expect(paths.userData).toBe(path.join(APP_DATA, 'mihomo-party-dev'))
   })
 
   it('leaves packaged stable and dev-release builds on production paths', async () => {
@@ -66,7 +74,7 @@ describe('configureAppPaths', () => {
 
     expect(setName).not.toHaveBeenCalled()
     expect(setPath).not.toHaveBeenCalled()
-    expect(paths.userData).toBe('/tmp/app-data/mihomo-party')
+    expect(paths.userData).toBe(path.join(APP_DATA, 'mihomo-party'))
   })
 
   it('keeps portable userData precedence over local development isolation', async () => {
@@ -75,10 +83,7 @@ describe('configureAppPaths', () => {
     configureAppPaths()
 
     expect(setName).toHaveBeenCalledWith('mihomo-party-dev')
-    expect(paths.userData).toBe('/tmp/runtime/Electron.app/Contents/MacOS/data')
-    expect(setPath).toHaveBeenLastCalledWith(
-      'userData',
-      '/tmp/runtime/Electron.app/Contents/MacOS/data'
-    )
+    expect(paths.userData).toBe(path.join(EXE_DIR, 'data'))
+    expect(setPath).toHaveBeenLastCalledWith('userData', path.join(EXE_DIR, 'data'))
   })
 })


### PR DESCRIPTION
test: make dirs.test.ts pass on Windows

dirs.test.ts asserts on values produced by `path.join`, but compares
them against hardcoded POSIX literals such as
'/tmp/app-data/mihomo-party-dev'. On Windows `path.join` returns
'\tmp\app-data\mihomo-party-dev', so two of the three cases fail on a
clean checkout:

  × isolates an unpackaged local development app
  × keeps portable userData precedence over local development isolation

The fs mock had the same problem: it detected the portable marker with
`value.endsWith('/PORTABLE')`, which never matches the backslash path
that `path.join` produces on Windows.

dirs.ts itself is correct; only the test encodes a platform assumption.
Build the expected values with `path.join` and match the portable
marker with `path.basename`, so the suite is platform-agnostic.

Full suite now passes on Windows 11: 20 files, 176 tests.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
Verified on Windows 11: `pnpm run review` (prettier + eslint + tsc) and `pnpm run test` (176 tests) pass, and `electron-vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
