### PR TITLE
fix: validate remote profiles before replacing them

### DIFF
--- a/src/main/config/profile.test.ts
+++ b/src/main/config/profile.test.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createProfile } from './profile'
+
+let testDir = ''
+
+const mocks = vi.hoisted(() => ({
+  axiosGet: vi.fn(),
+  checkProfileConfig: vi.fn(),
+  generateProfile: vi.fn(),
+  hotReload: vi.fn(),
+  restartCore: vi.fn()
+}))
+
+vi.mock('electron', () => ({ app: { getVersion: () => '2.0.0' } }))
+vi.mock('i18next', () => ({ default: { t: (key: string) => key } }))
+vi.mock('axios', () => ({ default: { get: mocks.axiosGet } }))
+vi.mock('../utils/age', () => ({
+  decryptAgeContent: (content: string) => Promise.resolve(content)
+}))
+vi.mock('../utils/dirs', () => ({
+  mihomoCorePath: () => join(testDir, 'mihomo'),
+  mihomoProfileWorkDir: (id: string) => join(testDir, 'work', id),
+  mihomoWorkDir: () => join(testDir, 'work'),
+  profileConfigPath: () => join(testDir, 'profile.yaml'),
+  profilePath: (id: string) => join(testDir, 'profiles', `${id}.yaml`)
+}))
+vi.mock('../utils/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+vi.mock('../resolve/server', () => ({ subStorePort: 8299 }))
+vi.mock('../core/mihomoApi', () => ({
+  mihomoCloseAllConnections: vi.fn(),
+  mihomoHotReloadConfig: mocks.hotReload
+}))
+vi.mock('../core/manager', () => ({
+  checkProfileConfig: mocks.checkProfileConfig,
+  restartCore: mocks.restartCore
+}))
+vi.mock('../core/factory', () => ({ generateProfile: mocks.generateProfile }))
+vi.mock('../core/profileUpdater', () => ({
+  addProfileUpdater: vi.fn(),
+  removeProfileUpdater: vi.fn()
+}))
+vi.mock('./app', () => ({
+  getAppConfig: () =>
+    Promise.resolve({
+      core: 'mihomo',
+      subscriptionTimeout: 30000,
+      userAgent: 'mihomo.party/v2.0.0 (clash.meta)'
+    })
+}))
+vi.mock('./controledMihomo', () => ({
+  getControledMihomoConfig: () => Promise.resolve({ 'mixed-port': 7890 })
+}))
+
+const oldProfile = `proxies:
+  - name: old
+    type: http
+    server: 127.0.0.1
+    port: 8080
+`
+
+const newProfile = `proxies:
+  - name: new
+    type: http
+    server: 127.0.0.1
+    port: 8081
+`
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'mihomo-party-profile-test-'))
+  mkdirSync(join(testDir, 'profiles'), { recursive: true })
+  writeFileSync(
+    join(testDir, 'profile.yaml'),
+    'current: remote\nitems:\n  - id: remote\n    type: remote\n    name: Remote\n'
+  )
+  writeFileSync(join(testDir, 'profiles', 'remote.yaml'), oldProfile)
+
+  vi.clearAllMocks()
+  mocks.axiosGet.mockResolvedValue({
+    status: 200,
+    data: newProfile,
+    headers: { 'content-type': 'text/yaml' }
+  })
+  mocks.generateProfile.mockResolvedValue('remote')
+  mocks.checkProfileConfig.mockResolvedValue(undefined)
+  mocks.hotReload.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('remote profile candidate validation', () => {
+  it('keeps the last-known-good profile when semantic validation fails', async () => {
+    mocks.checkProfileConfig.mockRejectedValueOnce(new Error("proxy 'missing-group' not found"))
+
+    await expect(
+      createProfile({ id: 'remote', type: 'remote', name: 'Remote', url: 'https://example.test' })
+    ).rejects.toThrow("proxy 'missing-group' not found")
+
+    expect(readFileSync(join(testDir, 'profiles', 'remote.yaml'), 'utf8')).toBe(oldProfile)
+    expect(mocks.generateProfile).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ profileId: 'remote', updateRuntimeConfig: false })
+    )
+    expect(mocks.hotReload).not.toHaveBeenCalled()
+  })
+
+  it('replaces the profile only after semantic validation succeeds', async () => {
+    await createProfile({
+      id: 'remote',
+      type: 'remote',
+      name: 'Remote',
+      url: 'https://example.test'
+    })
+
+    expect(mocks.checkProfileConfig).toHaveBeenCalledOnce()
+    expect(readFileSync(join(testDir, 'profiles', 'remote.yaml'), 'utf8')).toBe(newProfile)
+    expect(mocks.hotReload).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/config/profile.ts
+++ b/src/main/config/profile.ts
@@ -1,4 +1,4 @@
-import { access, readFile, rm, unlink } from 'fs/promises'
+import { access, mkdtemp, readFile, rm, unlink } from 'fs/promises'
 import { constants, existsSync } from 'fs'
 import { exec, execFile } from 'child_process'
 import { isAbsolute, join, relative, resolve } from 'path'
@@ -14,7 +14,7 @@ import { decryptAgeContent } from '../utils/age'
 import { DEFAULT_MIHOMO_PORTS } from '../../shared/appConfig'
 import { subStorePort } from '../resolve/server'
 import { mihomoCloseAllConnections, mihomoHotReloadConfig } from '../core/mihomoApi'
-import { restartCore } from '../core/manager'
+import { checkProfileConfig, restartCore } from '../core/manager'
 import { generateProfile } from '../core/factory'
 import { addProfileUpdater, removeProfileUpdater } from '../core/profileUpdater'
 import {
@@ -528,6 +528,7 @@ export async function createProfile(item: Partial<IProfileItem>): Promise<IProfi
       newItem.extra = parseSubinfo(headers['subscription-userinfo'])
     }
 
+    await validateRemoteProfileCandidate(newItem, data)
     await setProfileStr(id, data)
     await profileLogger.info(
       `Remote profile saved id=${id} name=${newItem.name} path=${profilePath(
@@ -542,6 +543,27 @@ export async function createProfile(item: Partial<IProfileItem>): Promise<IProfi
     return await promise
   } finally {
     inflightRemoteFetches.delete(dedupKey)
+  }
+}
+
+async function validateRemoteProfileCandidate(item: IProfileItem, content: string): Promise<void> {
+  const candidateDir = await mkdtemp(join(tmpdir(), 'mihomo-party-profile-'))
+  const candidatePath = join(candidateDir, 'config.yaml')
+
+  try {
+    const { core = 'mihomo' } = await getAppConfig()
+    const baseProfile = await parseProfileContent(item.id, content, item.ageSecretKey)
+    await generateProfile(undefined, {
+      profileId: item.id,
+      baseProfile,
+      ageSecretKey: item.ageSecretKey,
+      profileOverrideIds: item.override ?? [],
+      outputPath: candidatePath,
+      updateRuntimeConfig: false
+    })
+    await checkProfileConfig(candidatePath, core, item.ageSecretKey)
+  } finally {
+    await rm(candidateDir, { recursive: true, force: true }).catch(() => {})
   }
 }
 
@@ -577,11 +599,15 @@ export async function setProfileStr(id: string, content: string): Promise<void> 
 
 export async function getProfile(id: string | undefined): Promise<IMihomoConfig> {
   const item = await getProfileItem(id)
-  const profile = await decryptAgeContent(
-    await getProfileStr(id),
-    item?.ageSecretKey,
-    `profile "${id || 'default'}"`
-  )
+  return await parseProfileContent(id, await getProfileStr(id), item?.ageSecretKey)
+}
+
+export async function parseProfileContent(
+  id: string | undefined,
+  content: string,
+  ageSecretKey?: string
+): Promise<IMihomoConfig> {
+  const profile = await decryptAgeContent(content, ageSecretKey, `profile "${id || 'default'}"`)
 
   // 检测是否为 HTML 内容（订阅返回错误页面）
   const trimmed = profile.trim()

--- a/src/main/core/factory.ts
+++ b/src/main/core/factory.ts
@@ -33,6 +33,15 @@ const SMART_OVERRIDE_ID = 'smart-core-override'
 let runtimeConfigStr: string = ''
 let runtimeConfig: IMihomoConfig = {} as IMihomoConfig
 
+interface GenerateProfileOptions {
+  profileId?: string
+  baseProfile?: IMihomoConfig
+  ageSecretKey?: string
+  profileOverrideIds?: string[]
+  outputPath?: string
+  updateRuntimeConfig?: boolean
+}
+
 // 辅助函数：处理带偏移量的规则
 function processRulesWithOffset(ruleStrings: string[], currentRules: string[], isAppend = false) {
   const normalRules: string[] = []
@@ -108,26 +117,28 @@ function ensureSmartProxyServerTunExclude(profile: IMihomoConfig, enabled: boole
 }
 
 export async function generateProfile(
-  pendingControledMihomoConfig?: Partial<IMihomoConfig>
+  pendingControledMihomoConfig?: Partial<IMihomoConfig>,
+  options: GenerateProfileOptions = {}
 ): Promise<string | undefined> {
   // 读取最新的配置
   const { current } = await getProfileConfig(true)
+  const profileId = options.profileId ?? current
   const {
     diffWorkDir = false,
     controlDns = DEFAULT_CONTROL_DNS,
     controlSniff = DEFAULT_CONTROL_SNIFF,
     useNameserverPolicy
   } = await getAppConfig()
-  const currentProfileItem = await getProfileItem(current)
-  const ageSecretKey = currentProfileItem?.ageSecretKey || ''
-  const baseProfile = await getProfile(current)
-  const overrideIds = await getOrderedOverrideIds(current)
+  const currentProfileItem = await getProfileItem(profileId)
+  const ageSecretKey = options.ageSecretKey ?? currentProfileItem?.ageSecretKey ?? ''
+  const baseProfile = options.baseProfile ?? (await getProfile(profileId))
+  const overrideIds = await getOrderedOverrideIds(profileId, options.profileOverrideIds)
   const profileWithNormalOverride = await applyOverrides(
     baseProfile,
     overrideIds.normal,
     ageSecretKey
   )
-  const profileWithRuleOverride = await applyRuleOverride(current, profileWithNormalOverride)
+  const profileWithRuleOverride = await applyRuleOverride(profileId, profileWithNormalOverride)
   const currentProfile = await applyOverrides(
     profileWithRuleOverride,
     overrideIds.smart,
@@ -187,15 +198,18 @@ export async function generateProfile(
   }
   const coreConfigStr = stringify(coreProfile)
   if (diffWorkDir) {
-    await prepareProfileWorkDir(current)
+    await prepareProfileWorkDir(profileId)
   }
   await atomicWriteFile(
-    diffWorkDir ? mihomoWorkConfigPath(current) : mihomoWorkConfigPath('work'),
+    options.outputPath ??
+      (diffWorkDir ? mihomoWorkConfigPath(profileId) : mihomoWorkConfigPath('work')),
     coreConfigStr
   )
-  runtimeConfig = profile
-  runtimeConfigStr = nextRuntimeConfigStr
-  return current
+  if (options.updateRuntimeConfig !== false) {
+    runtimeConfig = profile
+    runtimeConfigStr = nextRuntimeConfigStr
+  }
+  return profileId
 }
 
 async function applyRuleOverride(
@@ -292,13 +306,16 @@ async function prepareProfileWorkDir(current: string | undefined): Promise<void>
   ])
 }
 
-async function getOrderedOverrideIds(current: string | undefined): Promise<{
+async function getOrderedOverrideIds(
+  current: string | undefined,
+  profileOverrideIds?: string[]
+): Promise<{
   normal: string[]
   smart: string[]
 }> {
   const { items = [] } = (await getOverrideConfig()) || {}
   const globalOverride = items.filter((item) => item.global).map((item) => item.id)
-  const { override = [] } = (await getProfileItem(current)) || {}
+  const override = profileOverrideIds ?? (await getProfileItem(current))?.override ?? []
   const orderedOverrideIds = [...new Set(globalOverride.concat(override))]
 
   return {

--- a/src/main/core/manager.ts
+++ b/src/main/core/manager.ts
@@ -932,20 +932,24 @@ async function checkProfile(
   diffWorkDir: boolean = false,
   ageSecretKey?: string
 ): Promise<void> {
+  await checkProfileConfig(
+    diffWorkDir ? mihomoWorkConfigPath(current) : mihomoWorkConfigPath('work'),
+    core,
+    ageSecretKey
+  )
+}
+
+export async function checkProfileConfig(
+  configPath: string,
+  core: string = 'mihomo',
+  ageSecretKey?: string
+): Promise<void> {
   const corePath = mihomoCorePath(core)
 
   try {
-    await execFilePromise(
-      corePath,
-      [
-        '-t',
-        '-f',
-        diffWorkDir ? mihomoWorkConfigPath(current) : mihomoWorkConfigPath('work'),
-        '-d',
-        mihomoTestDir()
-      ],
-      { env: buildCoreEnv(undefined, ageSecretKey) }
-    )
+    await execFilePromise(corePath, ['-t', '-f', configPath, '-d', mihomoTestDir()], {
+      env: buildCoreEnv(undefined, ageSecretKey)
+    })
   } catch (error) {
     managerLogger.error('Profile check failed', error)
 


### PR DESCRIPTION
## Summary

- treat every downloaded remote profile as a candidate before replacing persisted profile bytes
- build the effective runtime candidate with the existing controlled config, rules, and global/profile overrides
- run the selected Mihomo core's existing `-t` validation against a temporary candidate
- keep the runtime cache and persisted last-known-good profile unchanged when validation fails
- isolate and clean up the temporary runtime config because it can contain proxy credentials
- add regression coverage for rejected and successful updates

Closes #2047.

## Root cause

The download path only verified that a response was parseable YAML containing `proxies` or `proxy-providers`. `setProfileStr()` then atomically replaced the persisted source profile before the generated runtime configuration reached Mihomo's semantic check. A syntactically valid response with a dangling proxy-group reference could therefore replace a working current profile and make hot reload/restart fail.

This is separate from #2011: beb54159 recovers a stopped core before a later config push, while this change prevents an invalid update from replacing the last-known-good source profile in the first place.

## User impact

Remote updates that fail Mihomo validation now return the existing validation error without changing the saved profile or reloading the core. A later valid update proceeds normally.

## Validation

- `pnpm test` — 21 files, 178 tests passed
- `pnpm run review` — format, lint, Node typecheck, and web typecheck passed; lint reports only 12 pre-existing warnings outside this diff
- bundled Standard Mihomo `-t` — rejects a missing proxy-group reference with exit 1
- bundled Smart Mihomo `-t` — rejects the same candidate with exit 1
