### PR TITLE
fix: restore main window on second instance launch in linux

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -206,6 +206,7 @@ app.on('second-instance', (_event, commandline) => {
   }
   const pluginFile = findPluginFile(commandline)
   if (pluginFile) queueLaunchTarget({ type: 'plugin-file', value: pluginFile })
+  else showMainWindow()
 })
 
 app.on('open-url', (_event, url) => {


### PR DESCRIPTION
## 说明

修复 [#24e7e9b (perf: streamline app startup and shutdown)](https://github.com/mihomo-party-org/clash-party/commit/24e7e9b689ef88fb5dbf9b2463516bff14ee71c7) 导致Linux 桌面环境中，应用关闭窗口（最小化到托盘）后，点击应用列表或 dock/panel 中的 `.desktop` 图标无法重新显示主窗口的问题。

## 原因

[#00b8b569 (feat: add CPX plugin deep links)](https://github.com/mihomo-party-org/clash-party/commit/00b8b569c1898cc32c20a9497036ecdd1afadcf3) 将原本位于 `second-instance` 开头的无条件 `showMainWindow()` 移进了深链分支。随后的 [#726d12c7 (feat: associate CPX plugin files)](https://github.com/mihomo-party-org/clash-party/commit/726d12c74cf1ce6d10985f449e12655e2dc7fb81) 增加插件文件分支，但没有恢复普通启动兜底。

截止这里，构建在 Linux 桌面环境中仍能恢复窗口，这应是桌面环境或运行时额外提供了激活/聚焦兜底，而非应用代码保证的行为。

而在 [#24e7e9b (perf: streamline app startup and shutdown)](https://github.com/mihomo-party-org/clash-party/commit/24e7e9b689ef88fb5dbf9b2463516bff14ee71c7) 进行重构后，使该问题彻底暴露。

应用通过 `requestSingleInstanceLock()` 保持单实例。窗口隐藏后再次点击 `.desktop` 图标：

1. 新进程无法取得单实例锁并退出。
2. 已运行实例收到 second-instance。
3. 原处理器仅识别：
      - clash:// / mihomo:// 深链；
      - CPX 插件文件。

普通 `.desktop` 启动参数两者都不匹配，处理器直接结束，没有显示窗口。

## 修改

在 `second-instance` 事件中，若未检测到深链或插件文件，则调用 `showMainWindow()` 恢复并聚焦主窗口。

## 影响范围

- 修复 Linux 应用列表、dock/panel 固定图标的窗口恢复行为。
- 不改变深链和 `.cpx` 插件文件的既有处理流程。
- 不涉及托盘点击逻辑。

## 测试

已在 Fedora Linux 44（GNOME 50.3） 中构建测试，通过图标显示窗口的行为恢复正常。