### PR TITLE
fix: exclude divider height from title bar overlay

### DIFF
--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -175,7 +175,7 @@ async function createWindowInternal(): Promise<void> {
     titleBarOverlay: useWindowFrame
       ? false
       : {
-          height: 49
+          height: 47
         },
     autoHideMenuBar: true,
     // Win 显式指定 icon，避免异常/恢复路径下任务栏与窗口图标依赖默认 exe

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -102,7 +102,7 @@ const App: React.FC = () => {
 
   const setTitlebar = useCallback((): void => {
     if (!useWindowFrame && platform !== 'darwin') {
-      const options = { height: 48 } as TitleBarOverlayOptions
+      const options = { height: 47 } as TitleBarOverlayOptions
       try {
         options.color = window.getComputedStyle(document.documentElement).backgroundColor
         options.symbolColor = window.getComputedStyle(document.documentElement).color


### PR DESCRIPTION
The previous overlay height was 49px, which covered the divider. Reducing it to 48px might still left the divider covered, might be due to rounding during rendering. 

So the overlay height is set to 47px to expose the divider.

<img width="612" height="168" alt="image" src="https://github.com/user-attachments/assets/7d3c32f7-a9c3-4f6c-a4fd-becc1fb9b814" />
